### PR TITLE
BAU: Adds provisioned concurrency

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,7 @@ provider:
 
 functions:
   fpo_search:
+    provisionedConcurrency: 3
     image: ${env:DOCKER_IMAGE_URI}
     events:
       - http:


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added provisioned concurrency

### Why?

I am doing this because:

- This is a prerequisite for enabling faster lambda classifications
