### PR TITLE
BAU: Disable production deploys until we have our real domain name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,10 +94,10 @@ workflows:
           context: trade-tariff-lambda-deployments-staging
           <<: *filter-main
 
-  deploy-to-production:
-    jobs:
-      - deploy:
-          name: deploy-production
-          stage: production
-          context: trade-tariff-lambda-deployments-production
-          <<: *filter-main
+  # deploy-to-production:
+  #   jobs:
+  #     - deploy:
+  #         name: deploy-production
+  #         stage: production
+  #         context: trade-tariff-lambda-deployments-production
+  #         <<: *filter-main


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removed deploying to production

### Why?

I am doing this because:

- Since we aren't using the trade-tariff.service.gov.uk for the new infrastructure currently we can't reference the certificate that will end up existing under that domain.
- This stops us from having red builds for now

### AC

- No longer deploying to production
