### PR TITLE
BAU: Adds staging build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,13 +142,13 @@ workflows:
           name: build-staging
           context: trade-tariff-terraform-aws-staging
           environment: staging
-          <<: *filter-not-main
+          <<: *filter-main
 
       - deploy:
           name: deploy-staging
           stage: staging
           context: trade-tariff-lambda-deployments-staging
-          <<: *filter-not-main
+          <<: *filter-main
           requires:
             - build-staging
 


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added staging build step

### Why?

I am doing this because:

- This is a prerequisite getting the sanbox environment working

### AC

- Deploys to staging reference the current docker tag and deploy successfully
