### PR TITLE
HOTT-4469: Cut off any results lower than 5% to allow ambiguous terms to give no results

### DIFF
--- a/inference/infer.py
+++ b/inference/infer.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from sentence_transformers import SentenceTransformer
 import torch
 
+score_cutoff = 0.05  # We won't send back any results with a score lower than this
+
 
 class ClassificationResult:
     def __init__(self, code: str, score: float) -> None:
@@ -96,6 +98,10 @@ class FlatClassifier(Classifier):
         result = []
 
         for i in top_results:
+            # If the score is less than the cutoff then stop iterating through
+            if i[1] < score_cutoff:
+                break
+
             result.append(ClassificationResult(i[0], i[1]))
 
         return result


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4469

### What?

I have added/removed/altered:

- [x] Added a 0.05 cutoff to the results from the classifier

### Why?

I am doing this because:

- We want to allow the API to come back with less than 5, or no results, for the FPOs to be able to test those scenarios

### AC

- A search for something vague like 'gifts' comes back with no results
