### PR TITLE
HOTT-4507: Fix issue with missing sentence transformer model when running locally

### DIFF
--- a/api.py
+++ b/api.py
@@ -59,7 +59,7 @@ async def check_api_key(request: Request, call_next):
     return await call_next(request)
 
 
-@app.get("/code-search")
+@app.get("/fpo-code-search")
 async def search(q: str, digits: int = 6, limit: int = 5):
     start_time = time.time()
 

--- a/inference/infer.py
+++ b/inference/infer.py
@@ -50,7 +50,7 @@ class FlatClassifier(Classifier):
         print("Model loaded")
 
         # Use predownloaded transformer if available
-        if sentence_transformer_model_directory:
+        if Path(sentence_transformer_model_directory).exists():
             print(
                 f"💾⇨ Loading Sentence Transformer model from {sentence_transformer_model_directory}"
             )

--- a/train.py
+++ b/train.py
@@ -54,6 +54,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+digits = args.digits
 limit = args.limit
 force = args.force
 
@@ -125,7 +126,7 @@ else:
 
     training_data_loader = TrainingDataLoader()
 
-    (texts, labels, subheadings) = training_data_loader.fetch_data(data_sources, 8)
+    (texts, labels, subheadings) = training_data_loader.fetch_data(data_sources, digits)
 
     if limit is not None:
         texts = texts[:limit]


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4507

### What?

I have added/removed/altered:

- [x] Altered the check in `infer.py` for the pre-downloaded model so that it detects the file
- [x] A couple of other bits of tidying up

### Why?

I am doing this because:

- The API fails to run locally as it's looking for a model in `/tmp`

### AC

- `api.py` can be run locally
