### PR TITLE
HOTT-4547: Handle invalid JSON with a 400 response rather than 500

### DIFF
--- a/tests/aws_lambda/test_handler.py
+++ b/tests/aws_lambda/test_handler.py
@@ -155,7 +155,8 @@ class Test_handler_handle(unittest.TestCase):
         self.assertEqual(400, result["statusCode"], "Expected a 400 status code")
 
     def test_it_should_handle_invalid_json(self):
-        event = {"httpMethod": "POST", "body": "invalid json"}
+        event = self._create_post_event_default("test")
+        event["body"] = "invalid json"
 
         result = handler.handle(event, {})
 


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4547

### What?

I have added/removed/altered:

- [x] Added exception handling around the json decoding
- [x] Moved the authentication logic to the very start of the function

### Why?

I am doing this because:

- Requests with invalid JSON in the request body were returning a 500 error
- It's good practice to do the authentication before any other processing

### AC

- A POST request with invalid JSON in the body should return a 400 error
