### PR TITLE
NOJIRA: Fix an issue with loading the 'tradestats' data

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -8,7 +8,7 @@ from prettytable.colortable import ColorTable, Themes
 import tqdm
 
 from data_sources.data_source import DataSource
-from data_sources.tradesets import BasicCSVDataSource
+from data_sources.basic_csv import BasicCSVDataSource
 from inference.infer import FlatClassifier
 
 parser = argparse.ArgumentParser(description="Benchmark an FPO classification model.")

--- a/train.py
+++ b/train.py
@@ -6,7 +6,7 @@ import pickle
 import torch
 from data_sources.data_source import DataSource
 from data_sources.trade_tariff import TradeTariffDataSource
-from data_sources.tradesets import BasicCSVDataSource
+from data_sources.basic_csv import BasicCSVDataSource
 from training.create_embeddings import create_embeddings
 from training.prepare_data import TrainingDataLoader
 from training.train_model import (
@@ -124,7 +124,8 @@ else:
     tradesets_data_dir = source_dir / "tradesets_descriptions"
 
     data_sources += [
-        BasicCSVDataSource(filename) for filename in tradesets_data_dir.glob("*.csv")
+        BasicCSVDataSource(filename, encoding="latin_1")
+        for filename in tradesets_data_dir.glob("*.csv")
     ]
 
     training_data_loader = TrainingDataLoader()


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Altered the text encoding for the 'tradestats' data from UTF-8 to ISO-8859-1

### Why?

I am doing this because:

- There's an error loading the existing data as UTF-8

### AC

- The tradestats data can be loaded for training
