### PR TITLE
HOTT-4903: Add smoke test for production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,4 +196,4 @@ workflows:
           endpoint: https://search.trade-tariff.service.gov.uk
           requires:
             - deploy-production
-          <<: *filter-main
+          <<: *filter-release


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4903

### What?

I have added/removed/altered:

- [x] Added smoke test for production deploy

### Why?

I am doing this because:

- It's a good thing to do

### AC

- A basic smoke test runs after a production deploy
