### PR TITLE
Update huggingface-hub to fix a dependency conflict in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ fastapi==0.104.1
 filelock==3.13.1
 fsspec==2023.10.0
 h11==0.14.0
-huggingface-hub==0.17.3
+huggingface-hub~=0.2
 identify==2.5.31
 idna==3.4
 Jinja2==3.1.3
@@ -43,7 +43,7 @@ sniffio==1.3.0
 starlette==0.27.0
 sympy==1.12
 threadpoolctl==3.2.0
-tokenizers==0.14.1
+tokenizers==0.15.2
 torch==2.1.0
 torchvision==0.16.0
 tqdm==4.66.1


### PR DESCRIPTION
### Jira link
Maintainance.
No Jira ticket.

# What?
Update huggingface-hub to fix a dependency conflict in requirements.txt

I have added/removed/altered:
- updated huggingface-hub
- update tokenizer

### Why?
To fix dependency conflict in requirements.txt