### PR TITLE
FPO-56: Add in search references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ jobs:
           source venv/bin/activate
           pip install --no-cache-dir --upgrade torch --index-url https://download.pytorch.org/whl/cpu
           pip install --no-cache-dir --upgrade -r requirements_lambda.txt
+          # TODO: Add a separate requirements/test.txt
+          pip install pandas==2.2.1
           python -m unittest -v -b
 
   deploy:

--- a/data_sources/basic_csv.py
+++ b/data_sources/basic_csv.py
@@ -1,9 +1,14 @@
 import csv
+import os
 from os import PathLike
 import re
 from typing import Union
-
 from data_sources.data_source import DataSource
+import pandas as pd
+
+DEFAULT_SEARCH_REFERENCES_FILE = (
+    "raw_source_data/tradesets_descriptions/search_references_final8digit_16thFeb.csv"
+)
 
 
 class BasicCSVDataSource(DataSource):
@@ -12,6 +17,7 @@ class BasicCSVDataSource(DataSource):
         filename: Union[str, PathLike],
         code_col: int = 0,
         description_col: int = 1,
+        search_references_file: Union[str, PathLike] = DEFAULT_SEARCH_REFERENCES_FILE,
         encoding: str = "utf-8",
     ) -> None:
         super().__init__()
@@ -20,28 +26,54 @@ class BasicCSVDataSource(DataSource):
         self._description_col = description_col
         self._encoding = encoding
 
-    def get_codes(self, digits: int) -> dict[str, dict[str]]:
+        if os.path.isfile(search_references_file):
+            self._search_refs = pd.read_csv(search_references_file, dtype=str)
+        else:
+            self._search_refs = None
+
+    def get_codes(self, digits: int) -> dict[str, list[str]]:
         with open(self._filename, mode="r", encoding=self._encoding) as csv_file:
             csv_reader = csv.reader(csv_file)
             next(csv_reader)  # skip the first line (header)
             code_data = list(csv_reader)
 
-        documents = {}
+        codes = {}
 
-        for line in code_data:
-            subheading = line[self._code_col].strip()[:digits]
-            description = line[self._description_col].strip()
+        count = 0
+        for row in code_data:
+            subheading = row[self._code_col].strip()[:digits]
+            description = row[self._description_col].strip().lower()
 
             # Throw out any bad codes
             if not re.search("^\\d{" + str(digits) + "}$", subheading):
                 continue
 
-            if subheading in documents:
-                documents[subheading].add(description)
-            else:
-                documents[subheading] = {description}
+            if self._search_refs is not None:
+                # Check if the description exists in search references
+                if description in self._search_refs["GDSDESC"].values:
+                    count += 1
 
-        return documents
+                    # Find the corresponding CMDTYCODE for the description
+                    cmdtycode = (
+                        self._search_refs.loc[
+                            self._search_refs["GDSDESC"] == description, "CMDTYCODE"
+                        ]
+                        .iloc[0]
+                        .strip()[:digits]
+                    )
+                    row[
+                        self._code_col
+                    ] = cmdtycode  # replace the values in self._code_col with the corresponding CMDTYCODE from the mapping_dict if the description matches
+                    subheading = cmdtycode
+
+            if subheading in codes:
+                codes[subheading].add(description)
+            else:
+                codes[subheading] = {description}
+
+        print(f"Count of matches: {count}")
+
+        return codes
 
     def get_description(self) -> str:
         return f"CSV data source from {str(self._filename)}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ networkx==3.2.1
 nltk==3.8.1
 nodeenv==1.8.0
 numpy==1.26.2
+pandas==2.2.1
 packaging==23.2
 Pillow==10.1.0
 platformdirs==3.11.0

--- a/tests/data_sources/sample_data.csv
+++ b/tests/data_sources/sample_data.csv
@@ -4,3 +4,4 @@ Code,Description
 23456,Dried fruit
 34567,Wooden frames
 123,Invalid code
+88888888,Plastic Toys

--- a/tests/data_sources/sample_search_references.csv
+++ b/tests/data_sources/sample_search_references.csv
@@ -1,0 +1,4 @@
+CMDTYCODE,GDSDESC
+39269097,plastic toys
+39269097,"adaptor head units, plastic"
+90158020,aerological sounding apparatus

--- a/tests/data_sources/test_basic_csv.py
+++ b/tests/data_sources/test_basic_csv.py
@@ -1,6 +1,5 @@
 import logging
 import unittest
-
 from data_sources.basic_csv import BasicCSVDataSource
 
 logger = logging.getLogger()
@@ -9,29 +8,32 @@ logger.setLevel(logging.DEBUG)
 
 
 class Test_basic_csv_data_source(unittest.TestCase):
+    sample_file_path = "tests/data_sources/sample_data.csv"
+    sample_search_references_file = "tests/data_sources/sample_search_references.csv"
+    data_source = BasicCSVDataSource(
+        filename=sample_file_path,
+        search_references_file=sample_search_references_file,
+    )
+
     def test_initialization(self):
-        data_source = BasicCSVDataSource("test.csv")
-        self.assertEqual(data_source._filename, "test.csv")
-        self.assertEqual(data_source._code_col, 0)
-        self.assertEqual(data_source._description_col, 1)
-        self.assertEqual(data_source._encoding, "utf-8")
+        self.assertEqual(self.data_source._filename, self.sample_file_path)
+        self.assertEqual(self.data_source._code_col, 0)
+        self.assertEqual(self.data_source._description_col, 1)
+        self.assertEqual(self.data_source._encoding, "utf-8")
 
     def test_get_codes(self):
-        sample_file_path = "tests/data_sources/sample_data.csv"
-        data_source = BasicCSVDataSource(sample_file_path)
-
-        result = data_source.get_codes(digits=5)
+        result = self.data_source.get_codes(digits=5)
         expected = {
-            "12345": {"Fresh fish", "Raw ocean fish"},
-            "23456": {"Dried fruit"},
-            "34567": {"Wooden frames"},
+            "12345": {"fresh fish", "raw ocean fish"},
+            "23456": {"dried fruit"},
+            "34567": {"wooden frames"},
+            "39269": {"plastic toys"},
         }
         self.assertEqual(result, expected)
 
     def test_get_description(self):
-        data_source = BasicCSVDataSource("test.csv")
-        expected_description = "CSV data source from test.csv"
-        self.assertEqual(data_source.get_description(), expected_description)
+        expected_description = f"CSV data source from {self.sample_file_path}"
+        self.assertEqual(self.data_source.get_description(), expected_description)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/FPO-56

### What?

I have added/removed/altered:

- [x] Added the ability to force using search reference commodity codes when incorporating the tradeset terms into the model
- [x]  Added some tests of the basic csv data source api
- [x] Renamed some variables to match the actual returned codes

### Why?

I am doing this because:

- This is a feature requirement that comes from our stakeholders inside of HMRC

### AC

- Works across all scenarios (dev, test, production - production training isn't actually properly plumbed together yet so ignore that)

