### PR TITLE
Spike on Spelling correction. I've tried different solutions. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,11 +23,13 @@ networkx==3.2.1
 nltk==3.8.1
 nodeenv==1.8.0
 numpy==1.26.2
+openai==1.13.3
 packaging==23.2
 Pillow==10.1.0
 platformdirs==3.11.0
 pre-commit==3.5.0
 prettytable==3.9.0
+protobuf==4.25.3
 pydantic==2.5.0
 pydantic_core==2.14.1
 PyYAML==6.0.1

--- a/spelling_corrector_spike/gpt2_spelling_corrector.py
+++ b/spelling_corrector_spike/gpt2_spelling_corrector.py
@@ -1,0 +1,37 @@
+import torch
+from transformers import AutoTokenizer, GPT2LMHeadModel
+
+
+class GPT2SpellingCorrector:
+    def __init__(self, model_name="gpt2"):
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = GPT2LMHeadModel.from_pretrained("gpt2")
+
+    def correct(self, text):
+        input_ids = self.tokenizer.encode(text, return_tensors="pt")
+
+        # Generate attention mask
+        attention_mask = torch.ones(
+            input_ids.shape, dtype=torch.long, device=input_ids.device
+        )
+
+        # Generate corrected spelling
+        corrected_text = self.model.generate(
+            input_ids,
+            max_length=100,
+            attention_mask=attention_mask,
+            num_return_sequences=1,
+        )
+        return self.tokenizer.decode(corrected_text[0], skip_special_tokens=True)
+
+
+if __name__ == "__main__":
+    sc = GPT2SpellingCorrector()
+
+    text = """Correct the spelling of the following sentence:
+    WHITW WINE"""
+
+    print(f"input:{text}")
+
+    corrected_text = sc.correct(text)
+    print(f"corrected:{corrected_text}")

--- a/spelling_corrector_spike/nouns_spelling_corrector.py
+++ b/spelling_corrector_spike/nouns_spelling_corrector.py
@@ -1,0 +1,69 @@
+import spacy
+from spellchecker import SpellChecker
+import csv
+
+"""
+This script is a spike to test the spellchecker and the spacy library.
+The idea is to use spacy library to identify the NOUNS in the text and then use the spellchecker to correct them.
+The results are still pretty poor,
+unfortunatelly the missing context is a big problem and the spellchecker is not able to correct the words properly.
+A different approach would be using a LLM model to correct them.
+
+To run this script:
+python aws_lambda/contextual_corrector.py
+"""
+
+
+class NounsSpellingCorrector:
+    def __init__(self):
+        self.nlp = spacy.load("en_core_web_lg")
+        self.spell_checker = SpellChecker(distance=1)
+
+    def correct(self, text):
+        doc = self.nlp(text)
+        return doc._.outcome_spellCheck
+
+    def suggestions(self, text):
+        doc = self.nlp(text)
+        return doc._.suggestions_spellCheck
+
+
+if __name__ == "__main__":
+    cc = NounsSpellingCorrector()
+
+    # Load data from CSV file:
+    csv_file_path = (
+        "./raw_source_data/tradesets_descriptions/DEC22COMCODEDESCRIPTION.csv"
+    )
+    with open(csv_file_path, mode="r", encoding="utf-8") as file:
+        csv_reader = csv.reader(file)
+        next(csv_reader, None)
+
+        for line in csv_reader:
+            text = line[1]
+
+            doc = cc.nlp(text)
+
+            corrected = []
+
+            for token in doc:
+                if token.pos_ == "NOUN":
+                    tocken_corrected = cc.spell_checker.correction(token.text.strip())
+
+                    if tocken_corrected is not None:
+                        if tocken_corrected != token.text:
+                            print(text)
+                            print(f"{token.text}->{tocken_corrected}")
+
+                        corrected.append(tocken_corrected)
+                    else:
+                        corrected.append(token.text)
+                else:
+                    corrected.append(token.text)
+
+            corrected = [word for word in corrected if word is not None]
+
+            print(" ".join(corrected))
+
+            if corrected != token.text:
+                print(" --- ")

--- a/spelling_corrector_spike/openai_spelling_corrector.py
+++ b/spelling_corrector_spike/openai_spelling_corrector.py
@@ -1,0 +1,30 @@
+from openai import OpenAI
+
+
+class OpenAISpellingCorrector:
+    def __init__(self):
+        self.client = OpenAI(api_key="---REPLACE WITH YOUR OPENAI API KEY---")
+
+        # api_key=os.environ.get("OPENAI_API_KEY")
+
+    def correct(self, text):
+        completion = self.client.chat.completions.create(
+            model="gpt-3.5-turbo-0125",
+            messages=[
+                {"role": "system", "content": "You are a helpful spelling corrector."},
+                {"role": "user", "content": text},
+            ],
+        )
+        return completion.choices[0].message
+
+
+if __name__ == "__main__":
+    sc = OpenAISpellingCorrector()
+
+    text = """
+DESIGNER PRODUCTS
+DENTAL INSTRAMENTS
+TURTLA SNOOD
+"""
+
+    print(sc.correct(text))

--- a/spelling_corrector_spike/t5_spelling_corrector.py
+++ b/spelling_corrector_spike/t5_spelling_corrector.py
@@ -1,0 +1,31 @@
+from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+
+
+class T5SpellingCorrector:
+    def __init__(self):
+        self.tokenizer = AutoTokenizer.from_pretrained("google-t5/t5-base")
+        self.model = AutoModelForSeq2SeqLM.from_pretrained("google-t5/t5-base")
+
+    def correct(self, text):
+        input_ids = self.tokenizer.encode(text, return_tensors="pt")
+        sample_output = self.model.generate(
+            input_ids, do_sample=True, max_length=50, top_p=0.99, num_return_sequences=1
+        )
+        res = self.tokenizer.decode(sample_output[0], skip_special_tokens=True)
+        return res
+
+
+if __name__ == "__main__":
+    text = """Correct the errors in the following text:
+T-SHIRT CREW NECK S/S ESSENTIA
+WHITW WINE 1
+GALLERY DEPT. PAINT-SPLATTER DISTRE
+INDEXABLE IINSERT
+JEWELLARY
+GU8MMIES
+TANGY APPLE FLAVAOUR LABLES
+"""
+
+    t5 = T5SpellingCorrector()
+
+    print(t5.correct(text))


### PR DESCRIPTION
### Jira link


### What?
Spike on possible solutions to correct the spelling errors in the trade set description files (CSVs containing millions of lines).

I tried various solutions and placed them inside the /spelling_corrector_spike folder.

## What I tried:

I tried three approaches:

### Spelling libraries, like `PySpellChecker`
Result: Most of the corrections are incorrect. Also, it "corrects" words that are not misspelt, but that are not part of its dictionary. 

A problem with this solution is that it works on individual words and does not consider the context of each phrase. 

### Using transformer from HuggingFace

I tested a couple of transformers: ChatGpt2 and T5.

The results are inconsistent, and often, they add words instead of just correcting the phrases.

###OpenAPI - ChatGPT 3.5 Turbo
Pro:
This approach gives the best results, and it is effortless to implement.
Most of the time it provides perfect spelling correction, according with the context of the phrase.
Con:
This solution is not free, but it seem cheap: 2$ for 1Million of tokens (~1Mil. words) 

---

There is a potential good Mixed solution I have not tried:
Only use  OpenAPI for rows in which PySpellChecker has spotted a potential misspelling.
This way, we do NOT run costly queries for phrases that already appear correct.
