### PR TITLE
FPO-127: Retrieve search references from API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,6 @@ jobs:
           pip install --no-cache-dir --upgrade torch --index-url https://download.pytorch.org/whl/cpu
           pip install --no-cache-dir --upgrade -r requirements_lambda.txt
           # TODO: Add a separate requirements/test.txt
-          pip install pandas==2.2.1
           python -m unittest -v -b
 
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # The source data directory
 raw_source_data
 
-# The target directory for the training process
-target
-
 # VSCode files
 .vscode
 
@@ -84,6 +81,7 @@ docs/_build/
 # PyBuilder
 .pybuilder/
 target/
+target.zip
 
 # Jupyter Notebook
 .ipynb_checkpoints
@@ -172,5 +170,4 @@ cython_debug/
 # Serverless directories
 .serverless
 lambda/
-target.zip
 benchmarking_data

--- a/data_sources/search_references.py
+++ b/data_sources/search_references.py
@@ -1,0 +1,45 @@
+import requests
+
+
+class SearchReferences:
+    SEARCH_REFS_API_URL = (
+        "https://staging.trade-tariff.service.gov.uk/api/v2/search_references"
+    )
+
+    def __init__(self, url=SEARCH_REFS_API_URL):
+        self.url = url
+        self._commodities = None
+
+    def get_commodity_code(self, description):
+        commodity_code = None
+
+        if self.includes_description(description):
+            commodity_code = self.commodities()[description.strip().lower()]
+
+        return commodity_code
+
+    def includes_description(self, description):
+        return description.strip().lower() in self.commodities()
+
+    def commodities(self):
+        if self._commodities is not None:
+            return self._commodities
+
+        response = self._get()
+
+        json_entries = response["data"]
+
+        commodities = {}
+        for entry in json_entries:
+            if entry["attributes"]["referenced_class"] in ["Commodity", "Subheading"]:
+                commodities[
+                    entry["attributes"]["negated_title"].strip().lower()
+                ] = entry["attributes"]["goods_nomenclature_item_id"]
+
+        self._commodities = commodities
+        return commodities
+
+    def _get(self):
+        response = requests.get(self.url)
+
+        return response.json()

--- a/tests/data_sources/sample_data.csv
+++ b/tests/data_sources/sample_data.csv
@@ -5,3 +5,5 @@ Code,Description
 34567,Wooden frames
 123,Invalid code
 88888888,Plastic Toys
+,Empty code is ignored
+99999999,

--- a/tests/data_sources/test_basic_csv.py
+++ b/tests/data_sources/test_basic_csv.py
@@ -1,6 +1,9 @@
 import logging
 import unittest
+from unittest import mock
+
 from data_sources.basic_csv import BasicCSVDataSource
+from data_sources.search_references import SearchReferences
 
 logger = logging.getLogger()
 logger.addHandler(logging.StreamHandler())
@@ -9,11 +12,37 @@ logger.setLevel(logging.DEBUG)
 
 class Test_basic_csv_data_source(unittest.TestCase):
     sample_file_path = "tests/data_sources/sample_data.csv"
-    sample_search_references_file = "tests/data_sources/sample_search_references.csv"
+    search_references = SearchReferences(
+        url="http://localhost/test_search_references.json"
+    )
     data_source = BasicCSVDataSource(
         filename=sample_file_path,
-        search_references_file=sample_search_references_file,
+        search_references=search_references,
     )
+
+    response = {
+        "data": [
+            {
+                "attributes": {
+                    "referenced_class": "Commodity",
+                    "negated_title": "Fresh Fish",
+                    "goods_nomenclature_item_id": "12345",
+                }
+            },
+            {
+                "attributes": {
+                    "referenced_class": "Commodity",
+                    "negated_title": "Plastic Toys",
+                    "goods_nomenclature_item_id": "39269",
+                }
+            },
+        ]
+    }
+
+    def mock_response(self):
+        mock_resp = mock.Mock()
+        mock_resp.raise_for_status.side_effect = None
+        return mock_resp
 
     def test_initialization(self):
         self.assertEqual(self.data_source._filename, self.sample_file_path)
@@ -21,7 +50,9 @@ class Test_basic_csv_data_source(unittest.TestCase):
         self.assertEqual(self.data_source._description_col, 1)
         self.assertEqual(self.data_source._encoding, "utf-8")
 
-    def test_get_codes(self):
+    @mock.patch("requests.get", side_effect=mock_response)
+    def test_get_codes(self, _mock_get):
+        self.search_references._get = lambda: self.response
         result = self.data_source.get_codes(digits=5)
         expected = {
             "12345": {"fresh fish", "raw ocean fish"},

--- a/tests/data_sources/test_search_references.py
+++ b/tests/data_sources/test_search_references.py
@@ -1,0 +1,49 @@
+import unittest
+import logging
+from unittest import mock
+
+from data_sources.search_references import SearchReferences
+
+logger = logging.getLogger()
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.DEBUG)
+
+
+class Test_search_references(unittest.TestCase):
+    data_source = SearchReferences(url="http://localhost/test_search_references.json")
+
+    response = {
+        "data": [
+            {
+                "attributes": {
+                    "referenced_class": "Commodity",
+                    "negated_title": "Fresh Fish",
+                    "goods_nomenclature_item_id": "12345",
+                }
+            }
+        ]
+    }
+
+    def mock_response(self):
+        mock_resp = mock.Mock()
+        mock_resp.raise_for_status.side_effect = None
+        return mock_resp
+
+    @mock.patch("requests.get", side_effect=mock_response)
+    def test_get_commodity_code(self, _mock_get):
+        self.data_source._get = lambda: self.response
+        self.assertEqual(self.data_source.get_commodity_code("fresh fish"), "12345")
+
+    @mock.patch("requests.get", side_effect=mock_response)
+    def test_includes_description_when_exists_is_true(self, _mock_get):
+        self.data_source._get = lambda: self.response
+        self.assertTrue(self.data_source.includes_description("FRESH FISH"))
+
+    @mock.patch("requests.get", side_effect=mock_response)
+    def test_includes_description_when_non_existant_is_false(self, _mock_get):
+        self.data_source._get = lambda: self.response
+        self.assertFalse(self.data_source.includes_description("FOO BAR"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pickle
 
 import torch
+from data_sources.search_references import SearchReferences
 from data_sources.data_source import DataSource
 from data_sources.trade_tariff import TradeTariffDataSource
 from data_sources.basic_csv import BasicCSVDataSource
@@ -40,6 +41,8 @@ data_dir.mkdir(parents=True, exist_ok=True)
 # First load in the training data
 print("💾⇨ Loading training data")
 
+search_references = SearchReferences()
+
 texts_file = data_dir / "texts.pkl"
 labels_file = data_dir / "labels.pkl"
 subheadings_file = target_dir / "subheadings.pkl"
@@ -75,7 +78,9 @@ else:
     tradesets_data_dir = source_dir / "tradesets_descriptions"
 
     data_sources += [
-        BasicCSVDataSource(filename, encoding="latin_1")
+        BasicCSVDataSource(
+            filename, search_references=search_references, encoding="latin_1"
+        )
         for filename in tradesets_data_dir.glob("*.csv")
     ]
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/FPO-127

### What?

I have added/removed/altered:

- [x] Added class to encapsulate fetching search references from the OTT apis
- [x] Added test coverage which mocks requests to integrate with the api with a dummy response to validate behaviour 
- [x] Altered existing constructors to reflect change in basic csv interface

### Why?

I am doing this because:

- This is a prerequisite for incorporating search references from the API and making sure we've got decent coverage

### AC

- Properly unit tested
- Makes requests to the search references API

We're marking loading from environment variables as out of scope for now
