### PR TITLE
BAU: Log the api_key_id

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import pickle
 import time
 import os
-import json
 
 from aws_lambda.handler import LambdaHandler
 from aws_lambda_powertools import Logger
@@ -32,10 +31,7 @@ logger.info(
     "🚀⇨ Static classifier loaded in %.2fms", (time.perf_counter() - start) * 1000
 )
 
-fpo_client_keys = json.loads(os.environ.get("FPO_CLIENT_KEYS", "{}"))
-logger.info("🚀⇨ Loaded client keys", extra={"client_keys": fpo_client_keys.keys()})
-
-lambda_handler = LambdaHandler(classifier, fpo_client_keys, logger=logger)
+lambda_handler = LambdaHandler(classifier, logger=logger)
 
 
 @logger.inject_lambda_context

--- a/tests/aws_lambda/test_handler.py
+++ b/tests/aws_lambda/test_handler.py
@@ -5,8 +5,6 @@ from aws_lambda.handler import LambdaHandler
 
 from inference.infer import ClassificationResult, Classifier
 
-test_fpo_client_keys = {"test_id": "test_secret"}
-
 logger = logging.getLogger()
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.DEBUG)
@@ -24,7 +22,7 @@ class MockClassifier(Classifier):
 
 classifier = MockClassifier()
 
-handler = LambdaHandler(classifier, test_fpo_client_keys)
+handler = LambdaHandler(classifier)
 
 
 class Test_handler_handle(unittest.TestCase):
@@ -135,8 +133,7 @@ class Test_handler_handle(unittest.TestCase):
                 "limit": limit,
             },
             "headers": {
-                "x-api-client-id": "test_id",
-                "x-api-secret-key": "test_secret",
+                "x-api-key": "test_id",
             },
         }
 
@@ -147,8 +144,7 @@ class Test_handler_handle(unittest.TestCase):
                 "q": description,
             },
             "headers": {
-                "x-api-client-id": "test_id",
-                "x-api-secret-key": "test_secret",
+                "x-api-key": "test_id",
             },
         }
 
@@ -159,8 +155,7 @@ class Test_handler_handle(unittest.TestCase):
                 {"description": description, "digits": digits, "limit": limit}
             ),
             "headers": {
-                "x-api-client-id": "test_id",
-                "x-api-secret-key": "test_secret",
+                "x-api-key": "test_id",
             },
         }
 
@@ -173,8 +168,7 @@ class Test_handler_handle(unittest.TestCase):
                 {"description": description, "digits": digits, "limit": limit}
             ),
             "headers": {
-                "x-api-client-id": "test_id",
-                "x-api-secret-key": "test_secret",
+                "x-api-key": "test_id",
             },
         }
 
@@ -183,8 +177,7 @@ class Test_handler_handle(unittest.TestCase):
             "httpMethod": "POST",
             "body": json.dumps({"description": description}),
             "headers": {
-                "x-api-client-id": "test_id",
-                "x-api-secret-key": "test_secret",
+                "x-api-key": "test_id",
             },
         }
 


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Extended the log output to include the api key id

### Why?

I am doing this because:

- This comes in with authenticated requests via managed API keys
