### PR TITLE
FPO-170: Migrate to using staging and not sandbox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ workflows:
       - smoketest:
           name: smoketest-staging
           context: trade-tariff-lambda-deployments-staging
-          endpoint: https://search.sandbox.trade-tariff.service.gov.uk
+          endpoint: https://search.staging.trade-tariff.service.gov.uk
           requires:
             - deploy-staging
           <<: *filter-main

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ deploy-development:
 	PRIVATE_ENABLED=false STAGE=development serverless deploy --verbose --param="custom_domain=search.dev.trade-tariff.service.gov.uk" --param="certificate_domain=dev.trade-tariff.service.gov.uk"
 
 deploy-staging:
-	PRIVATE_ENABLED=false STAGE=staging serverless deploy --verbose --param="custom_domain=search.sandbox.trade-tariff.service.gov.uk" --param="certificate_domain=sandbox.trade-tariff.service.gov.uk"
+	PRIVATE_ENABLED=false STAGE=staging serverless deploy --verbose --param="custom_domain=search.staging.trade-tariff.service.gov.uk" --param="certificate_domain=staging.trade-tariff.service.gov.uk"
 
 deploy-production:
 	PRIVATE_ENABLED=true STAGE=production DOCKER_TAG=$$DOCKER_TAG serverless deploy --verbose --param="custom_domain=search.trade-tariff.service.gov.uk" --param="certificate_domain=trade-tariff.service.gov.uk"


### PR DESCRIPTION
### Jira link

FPO-170

### What?

I have added/removed/altered:

- [x] Migrate to using staging over sandbox

### Why?

I am doing this because:

- This is just a vanity domain that is in our staging account
