### PR TITLE
FPO-97: Simplify API design and remove GET /fpo-code-search

### DIFF
--- a/.circleci/bin/smoketest
+++ b/.circleci/bin/smoketest
@@ -9,15 +9,6 @@ set -o noclobber
 URL=$1
 API_KEY=$2
 
-# Ensure it responds with a 200 to a GET request
-STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${URL}/fpo-code-search?q=grilled+cheese&digits=6" \
-  -H "X-Api-Key: ${API_KEY}")
-
-if [[ "$STATUS_CODE" -ne 200 ]] ; then
-  echo "ERROR: Status code of $STATUS_CODE" >&2
-  exit 1
-fi
-
 # Ensure it responds with a 200 to a POST request
 STATUS_CODE=$(curl -X POST -d '{"description":"grilled cheese"}' -s -o /dev/null -w "%{http_code}" "${URL}/fpo-code-search" \
   -H "X-Api-Key: $API_KEY")
@@ -35,7 +26,7 @@ if [[ "$STATUS_CODE" -ne 200 ]] ; then
   exit 1
 fi
 
-# Ensure it responds with a 401 if credentials are missing
+# Ensure it responds with a 403 if credentials are missing
 STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${URL}/fpo-code-search?q=grilled+cheese&digits=6")
 
 if [[ "$STATUS_CODE" -ne 403 ]] ; then

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ run: build
 test-local:
 	curl http://localhost:9000/2015-03-31/functions/function/invocations \
 		--header 'Content-Type: application/json' \
-		--data '{"httpMethod": "GET", "queryStringParameters": {"q": "haddock"}}'
+		--data '{"path": "/fpo-code-search", "httpMethod": "POST", "body": "{\"description\": \"toothbrushes\"}"}'
 
 shell:
 	docker run \

--- a/aws_lambda/handler.py
+++ b/aws_lambda/handler.py
@@ -84,17 +84,6 @@ class LambdaHandler:
 
         return response
 
-    @log_handler
-    def handle_fpo_code_search_get(self, event, _context):
-        description = event.get("queryStringParameters", {}).get("q", "")
-        digits = event.get("queryStringParameters", {}).get("digits", "6")
-        limit = event.get("queryStringParameters", {}).get("limit", "5")
-
-        response = self._handle_classification(description, digits, limit)
-        response["headers"] = self._headers(event)
-
-        return response
-
     def handle_healthcheck_get(self, event, _context):
         return {
             "statusCode": 200,

--- a/serverless.yml
+++ b/serverless.yml
@@ -38,10 +38,6 @@ functions:
     events:
       - http:
           path: /fpo-code-search
-          method: get
-          private: true
-      - http:
-          path: /fpo-code-search
           method: post
           private: true
       - http:

--- a/tests/aws_lambda/test_handler.py
+++ b/tests/aws_lambda/test_handler.py
@@ -26,38 +26,6 @@ handler = LambdaHandler(classifier)
 
 
 class Test_handler_handle(unittest.TestCase):
-    def test_it_should_handle_a_valid_get_request(self):
-        event = self._create_get_event("test", "8", "5")
-
-        result = handler.handle(event, {})
-        self.assertEqual(200, result["statusCode"], "Expected a 200 status code")
-        self.assertEqual(
-            5, len(json.loads(result["body"])["results"]), "Expected 5 results"
-        )
-        self.assertEqual(
-            "6b85ab53-2b60-4178-81ce-342acdec65a2",
-            result["headers"]["X-Request-Id"],
-            "Expected a request id",
-        )
-
-    def test_it_should_handle_a_valid_get_request_default_args(self):
-        event = self._create_get_event_default("test")
-
-        result = handler.handle(event, {})
-        result_body = json.loads(result["body"])
-        self.assertEqual(200, result["statusCode"], "Expected a 200 status code")
-        self.assertEqual(
-            6,
-            len(result_body["results"][0]["code"]),
-            "Expected default results to have 6 digits",
-        )
-        self.assertEqual(5, len(result_body["results"]), "Expected 5 default results")
-        self.assertEqual(
-            "6b85ab53-2b60-4178-81ce-342acdec65a2",
-            result["headers"]["X-Request-Id"],
-            "Expected a request id",
-        )
-
     def test_it_should_handle_a_valid_post_request(self):
         event = self._create_post_event("test", "6", "5")
 
@@ -197,34 +165,6 @@ class Test_handler_handle(unittest.TestCase):
             "Expected a 200 status code",
         )
 
-    def _create_get_event(self, description: str, digits: str = "6", limit: str = "5"):
-        return {
-            "path": "/fpo-code-search",
-            "httpMethod": "GET",
-            "queryStringParameters": {
-                "q": description,
-                "digits": digits,
-                "limit": limit,
-            },
-            "headers": {
-                "x-api-key": "test_secret",
-            },
-            "requestContext": {"requestId": "6b85ab53-2b60-4178-81ce-342acdec65a2"},
-        }
-
-    def _create_get_event_default(self, description: str):
-        return {
-            "path": "/fpo-code-search",
-            "httpMethod": "GET",
-            "queryStringParameters": {
-                "q": description,
-            },
-            "headers": {
-                "x-api-key": "test_secret",
-            },
-            "requestContext": {"requestId": "6b85ab53-2b60-4178-81ce-342acdec65a2"},
-        }
-
     def _create_post_event(self, description: str, digits: str = "6", limit: str = "5"):
         return {
             "path": "/fpo-code-search",
@@ -232,9 +172,6 @@ class Test_handler_handle(unittest.TestCase):
             "body": json.dumps(
                 {"description": description, "digits": digits, "limit": limit}
             ),
-            "headers": {
-                "x-api-key": "test_secret",
-            },
             "requestContext": {"requestId": "6b85ab53-2b60-4178-81ce-342acdec65a2"},
         }
 
@@ -247,9 +184,6 @@ class Test_handler_handle(unittest.TestCase):
             "body": json.dumps(
                 {"description": description, "digits": digits, "limit": limit}
             ),
-            "headers": {
-                "x-api-key": "test_secret",
-            },
             "requestContext": {"requestId": "6b85ab53-2b60-4178-81ce-342acdec65a2"},
         }
 
@@ -258,9 +192,6 @@ class Test_handler_handle(unittest.TestCase):
             "path": "/fpo-code-search",
             "httpMethod": "POST",
             "body": json.dumps({"description": description}),
-            "headers": {
-                "x-api-key": "test_secret",
-            },
             "requestContext": {"requestId": "6b85ab53-2b60-4178-81ce-342acdec65a2"},
         }
 
@@ -268,9 +199,6 @@ class Test_handler_handle(unittest.TestCase):
         return {
             "path": "/unknown",
             "httpMethod": "GET",
-            "headers": {
-                "x-api-key": "test_secret",
-            },
             "requestContext": {"requestId": "6b85ab53-2b60-4178-81ce-342acdec65a2"},
         }
 


### PR DESCRIPTION
### Jira link

FPO-97

### What?

I have added/removed/altered:

- [x] Removed GET /fpo-code-search handler and smoke- and unit- tests
- [x] Updated test-local Makefile target to use the POST /fpo-code-search handler

### Why?

I am doing this because:

- This is to required to reflect the state of our API documentation (https://github.com/trade-tariff/trade-tariff-api-docs/pull/117)
