### PR TITLE
BAU: Fixes threshold for cold start of lambdas

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -105,7 +105,7 @@ resources:
         Statistic: Average
         Period: 300 # 5 minutes
         EvaluationPeriods: 1
-        Threshold: 2000 # 2 seconds
+        Threshold: 14000 # 14 seconds for a cold start of a lambda
         ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - arn:aws:sns:${self:provider.region}:${aws:accountId}:slack-topic


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Altered threshold of lambda duration alarm to reflect cold starts

### Why?

I am doing this because:

- This is reduce alarm noise
