### PR TITLE
FPO-195: Error running train.py when /tmp is on a different filesystem

### DIFF
--- a/training/create_embeddings.py
+++ b/training/create_embeddings.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 import pickle
 import shutil
-import tempfile
 from typing import Optional
 import numpy as np
 from sentence_transformers import SentenceTransformer
@@ -50,12 +49,12 @@ class EmbeddingsProcessor:
     def _save_cache(self):
         if self._cache_file is not None:
             self._logger.info("💾⇦ Saving embedding cache")
+
             # Write to a temp file first so that we don't corrupt an existing file
+            temp_file_path = str(self._cache_file) + ".tmp"
 
-            with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            with open(temp_file_path, "wb") as temp_file:
                 pickle.dump(self._cache, temp_file)
-
-                temp_file_path = temp_file.name
 
             shutil.move(temp_file_path, self._cache_file)
 

--- a/training/create_embeddings.py
+++ b/training/create_embeddings.py
@@ -2,6 +2,7 @@ import logging
 import os
 from pathlib import Path
 import pickle
+import shutil
 import tempfile
 from typing import Optional
 import numpy as np
@@ -56,7 +57,7 @@ class EmbeddingsProcessor:
 
                 temp_file_path = temp_file.name
 
-            os.replace(temp_file_path, self._cache_file)
+            shutil.move(temp_file_path, self._cache_file)
 
     def create_embeddings(self, texts: list[str]):
         self._logger.info(f"ℹ️  Creating embeddings for {len(texts)} texts")


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/FPO-195

### What?

I have added/removed/altered:

- [x] Altered the temporary embedding cache file to use `shutil.move()` rather than `os.rename()` as that will handle cross-filesystem moves.
- [x] I have also moved the location of the temporary file to the same folder so that they are likely to be on the same filesystem

### Why?

I am doing this because:

- It wasn't working before if /tmp was on a different filesystem
