### PR TITLE
FPO-300: Enable rolling back models

### DIFF
--- a/.circleci/bin/needsmodel
+++ b/.circleci/bin/needsmodel
@@ -5,17 +5,21 @@ set -o nounset
 set -o pipefail
 set -o noclobber
 
-versionchanged ()
-{
-  git diff "$(git merge-base main HEAD)"..HEAD -- search-config.toml \
-    | grep -e +version -e -version
-}
-
 needsmodel ()
 {
-  if [[ -z "$(versionchanged)" ]]; then
+  versions_unsorted=$(git --no-pager diff main search-config.toml | grep version | sed 's/^[+|-]//g')
+  versions_sorted=$(git --no-pager diff main search-config.toml | grep version | sed 's/^[+|-]//g' | sort)
+
+  # No change to versions
+  if [[ -z "$versions_unsorted" ]]; then
     return 1
-  else
-    return 0
   fi
+
+  # Version has been rolled back
+  if [[ "$versions_unsorted" != "$versions_sorted" ]]; then
+    return 1
+  fi
+
+  # Version has been updated
+  return 0
 }

--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.3.0"
+version = "1.3.1"
 learning_rate = 0.0011
 max_epochs = 4
 model_batch_size = 1000


### PR DESCRIPTION
### Jira link

FPO-300

### What?

I have added/removed/altered:

- [x] Enable rolling back model versions

### Why?

I am doing this because:

- We need to support the ability for the configured version of the model to go down
- In this situation we do not build a new model and instead allow the user to rollback to an older version of the model

### AC

- Models can be set to older versions without kicking off the training pipeline
