### PR TITLE
FPO-312: Reflect cold start change with larger files

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -100,7 +100,7 @@ resources:
         Statistic: Average
         Period: 300 # 5 minutes
         EvaluationPeriods: 1
-        Threshold: 14000 # 14 seconds for a cold start of a lambda
+        Threshold: 20000 # 20 seconds for a cold start of a lambda
         ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - arn:aws:sns:${self:provider.region}:${aws:accountId}:slack-topic


### PR DESCRIPTION
### Jira link

FPO-312

### What?

I have added/removed/altered:

- [x] Increased the alarm for the lambda duration to be 20 seconds

### Why?

I am doing this because:

- The amount of time it takes to cold start the FPO lambdas has increased to c 16 seconds (from about 12 previously) due to the inclusion of more tradestats data in the model
- Alarms are being triggered but are really within acceptable tolerance

### AC

- Alarms aren’t being triggered
