### PR TITLE
FPO-331: Be stricter about instance rotation

### DIFF
--- a/.circleci/bin/clearinstances
+++ b/.circleci/bin/clearinstances
@@ -9,7 +9,7 @@ fetch_ec2_instances_for_termination ()
 {
   aws ec2 describe-instances \
           --region "us-east-1" \
-          --query 'Reservations[*].Instances[?Tags[?Key==`Name` && starts_with(Value, `fpo-search-training-`)] && State.Name==`running`].InstanceId' \
+          --query 'Reservations[*].Instances[?State.Name==`running`].InstanceId' \
           --output text |
           tr '\n' ' '
 }


### PR DESCRIPTION
### Jira link

FPO-331

### What?

I have added/removed/altered:

- [x] Added stricter rotation parameters to the clearinstances script

### Why?

I am doing this because:

- We had this issue where a training instance wasn't tagged correctly and so wasn't rotated overnight
- This has cost the customer a lot of money (3k)

### AC

- All instances in us-east-1 are now being rotated
