### PR TITLE
FPO-373: Clean while inferring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,3 +28,13 @@ model.zip
 embeddings.zip
 .vscode
 .DS_Store
+old_benchmark
+new_benchmark
+benchmarking_data
+node_modules
+benchmark_results.zip
+tests
+.circleci
+.packer
+docs
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade torch --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --upgrade -r requirements_lambda.txt
 
-RUN python download_transformer.py
+RUN python download_transformer.py && \
+  rm -f "$SENTENCE_TRANSFORMERS_HOME/sentence-transformers_${SENTENCE_TRANSFORMER_PRETRAINED_MODEL}/model.safetensors" # We use torch weight files
 
 CMD ["handler.handle"]

--- a/aws_lambda/handler.py
+++ b/aws_lambda/handler.py
@@ -161,16 +161,6 @@ class LambdaHandler:
 
         cleaned = pipeline.filter("", description)
 
-        self._logger.info(
-            "Cleaning pipeline",
-            extra={
-                "request_description": description,
-                "cleaned_description": cleaned,
-                "digits": digits,
-                "limit": limit,
-            },
-        )
-
         if cleaned is None:
             return {
                 "statusCode": 400,

--- a/benchmark.py
+++ b/benchmark.py
@@ -14,6 +14,7 @@ from prettytable import PrettyTable
 from prettytable.colortable import ColorTable, Themes
 from training.cleaning_pipeline import (
     CleaningPipeline,
+    DescriptionLower,
     LanguageCleaning,
     RemoveDescriptionsMatchingRegexes,
     RemoveEmptyDescription,
@@ -124,6 +125,7 @@ with open(language_keeps_exact_file, "r") as f:
 filters = [
     StripExcessWhitespace(),
     RemoveEmptyDescription(),
+    DescriptionLower(),
     RemoveShortDescription(min_length=4),
     RemoveSubheadingsNotMatchingRegexes(regexes=["^\d{" + str(args.digits) + "}$"]),
     RemoveDescriptionsMatchingRegexes(

--- a/requirements_lambda.txt
+++ b/requirements_lambda.txt
@@ -1,5 +1,6 @@
 aws-lambda-powertools==2.28.1
 jmespath==1.0.1
+lingua-language-detector==2.0.2
 sentence-transformers==2.2.2
 sentry-sdk==1.45.0
 toml==0.10.2

--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.5.2"
+version = "1.5.1"
 learning_rate = 0.0011
 max_epochs = 4
 model_batch_size = 1000

--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.5.1"
+version = "1.5.2"
 learning_rate = 0.0011
 max_epochs = 4
 model_batch_size = 1000

--- a/train.py
+++ b/train.py
@@ -13,6 +13,7 @@ from training.create_embeddings import EmbeddingsProcessor
 
 from training.cleaning_pipeline import (
     CleaningPipeline,
+    DescriptionLower,
     LanguageCleaning,
     NegationCleaning,
     RemoveDescriptionsMatchingRegexes,
@@ -64,6 +65,7 @@ with open(language_keeps_exact_file, "r") as f:
 basic_filters = [
     StripExcessWhitespace(),
     RemoveEmptyDescription(),
+    DescriptionLower(),
     RemoveShortDescription(min_length=1),
     RemoveSubheadingsNotMatchingRegexes(
         regexes=[

--- a/training/cleaning_pipeline.py
+++ b/training/cleaning_pipeline.py
@@ -237,3 +237,8 @@ class NegationCleaning(Cleaner):
         description = re.sub(self._full_negation_regex, "", description).strip()
 
         return (subheading, description)
+
+class DescriptionLower(Cleaner):
+    @debug
+    def filter(self, subheading: str, description: str) -> tuple[str, str] | None:
+        return (subheading, description.lower())


### PR DESCRIPTION
### Jira link

FPO-373

### What?

I have added/removed/altered:

- Lower descriptions when we apply the cleaning pipeline
- Optimise the dockerignore file
- Remove unused safetensor weights
- Adds cleaning during infererence
- Cut new model

### Why?

I am doing this because:

- This makes us consistent with training
- This makes us more robust to classifying garbage inputs

### AC

- Added some simple smoke tests to cover simple cleaning scenarios
- Validated in a live environment
