### PR TITLE
BAU: Fixes handling of vague terms

### DIFF
--- a/.circleci/bin/smoketest
+++ b/.circleci/bin/smoketest
@@ -29,6 +29,16 @@ function has_correct_code() {
     jq ".results | .[] | select(.code == \"$expected_code\") | any"
 }
 
+function has_no_results() {
+  description=$1
+
+  curl --silent -X POST $URL/fpo-code-search \
+    -H 'Content-Type: application/json' \
+    -H "X-Api-Key: $API_KEY" \
+    -d "{\"description\":\"$description\"}" | \
+    jq ".results | length == 0"
+}
+
 # Ensure it handles search references
 HAS_CORRECT_CODE=$(has_correct_code "ricotta" "040610")
 
@@ -38,10 +48,10 @@ if [[ "$HAS_CORRECT_CODE" != "true" ]] ; then
 fi
 
 # Ensure it handles vague terms
-HAS_CORRECT_CODE=$(has_correct_code "bits" "vvvvvv")
+HAS_NO_RESULTS=$(has_no_results "bits")
 
-if [[ "$HAS_CORRECT_CODE" != "true" ]] ; then
-  echo "ERROR: Expected vague term code not found" >&2
+if [[ "$HAS_NO_RESULTS" != "true" ]] ; then
+  echo "ERROR: Expected no results for vague term" >&2
   exit 1
 fi
 

--- a/aws_lambda/handler.py
+++ b/aws_lambda/handler.py
@@ -4,7 +4,6 @@ from typing import Union
 import aws_lambda_powertools
 
 from inference.infer import Classifier, ClassificationResult
-from inference.infer import vague_term_code
 from data_sources.search_references import SearchReferencesDataSource
 from data_sources.vague_terms import VagueTermsCSVDataSource
 from train_args import TrainScriptArgsParser
@@ -207,7 +206,9 @@ class LambdaHandler:
 
         early_result = self._early_result(cleaned_description, digits)
 
-        if early_result:
+        if early_result is None:
+            results = []
+        elif early_result:
             results = early_result
         else:
             results = self._classifier.classify(
@@ -235,13 +236,13 @@ class LambdaHandler:
 
     def _early_result(
         self, description: str, digits: Union[str, int]
-    ) -> list[ClassificationResult]:
+    ) -> list[ClassificationResult] | None:
         result = []
         code = None
         score = 0.0
 
         if self._vague_terms.includes_description(description):
-            code = vague_term_code
+            return None
 
         search_reference_code = self._search_references.get_commodity_code(description)
 

--- a/tests/aws_lambda/test_handler.py
+++ b/tests/aws_lambda/test_handler.py
@@ -65,7 +65,7 @@ class Test_handler_handle(unittest.TestCase):
 
         self.assertEqual(200, result["statusCode"], "Expected a 200 status code")
         self.assertEqual(
-            {"results": [{"code": "vvvvvv", "score": 0.00}]},
+            {"results": []},
             result_body,
             "Expected 1 result",
         )


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Altered handling of vague terms in classification tool

### Why?

I am doing this because:

- This is needed to make sure the semantics of the api haven't diverged from their documented semantics
