### PR TITLE
FPO-404: Adds multi-region training support

### DIFF
--- a/.circleci/bin/buildmodel
+++ b/.circleci/bin/buildmodel
@@ -15,7 +15,7 @@ fetch_account_id ()
 fetch_latest_ami_image_id_by_name ()
 {
   image_name_query=$1
-  region='us-east-1'
+  region=${2:-'us-east-1'}
   owner=$(fetch_account_id)
 
   aws ec2 describe-images \
@@ -26,39 +26,45 @@ fetch_latest_ami_image_id_by_name ()
     --output text
 }
 
-fetch_subnet_by_cidr ()
-{
-  region='us-east-1'
-
-  aws ec2 describe-subnets --filters "Name=cidrBlock,Values=$1" --region "$region" --query 'Subnets[0].SubnetId' --output text
-}
-
-fetch_security_group_by_name ()
-{
-  region='us-east-1'
-
-  aws ec2 describe-security-groups --filters "Name=group-name,Values=$1" --region "$region" --query 'SecurityGroups[0].GroupId' --output text
-}
-
 INSTANCE_ID=''
 
 launch_ec2_instance ()
 {
   name="fpo-search-training-$SHA"
-  retries=5
-  delay=10
+  retries=2
+  delay=5
+  region=$1
+  az=$2
+  subnet_id=$3
+  security_group_ids=$4
+  key_pair_name=$5
+  instance_type=$6
+  source_ami_region="us-east-1"
+  .circleci/bin/copyami "$LATEST_AMI" "$source_ami_region" "$region"
+  ami_id=$(fetch_latest_ami_image_id_by_name "FPO Training*" "$region")
+
+  echo "Launching EC2 instance in $region with configuration..."
+  echo
+  echo "🌍 Region: $region"
+  echo "📀 AMI: $ami_id"
+  echo "🤖 Instance Type: $instance_type"
+  echo "☎️📞Subnet ID: $subnet_id"
+  echo "🔓 Security Group IDs: $security_group_ids"
+  echo "🔓 Key Pair Name: $key_pair_name"
+  echo "🚀 Instance Name: $name"
+  echo
 
   for ((i=0; i<retries; i++)); do
     set +o errexit
     INSTANCE_ID=$(aws ec2 run-instances \
-      --image-id "$LATEST_AMI" \
-      --subnet-id "$SUBNET_ID" \
-      --security-group-ids "$SECURITY_GROUP_IDS" \
-      --instance-type p3.8xlarge \
-      --key-name "$KEY_PAIR_NAME" \
+      --image-id "$ami_id" \
+      --subnet-id "$subnet_id" \
+      --security-group-ids "$security_group_ids" \
+      --instance-type $instance_type \
+      --key-name "$key_pair_name" \
       --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":512,"DeleteOnTermination":true}}]' \
       --associate-public-ip-address \
-      --region 'us-east-1' \
+      --region "$region" \
       --output text \
       --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$name}]" \
       --query 'Instances[0].InstanceId' 2>&1)
@@ -71,25 +77,54 @@ launch_ec2_instance ()
 
     echo "Insufficient capacity. Retrying in $delay seconds..."
     sleep "$delay"
-    delay=$((delay * 2))  # Exponential backoff
+    delay=$((delay * 2))
   done
 
-  echo "Failed to launch instance after $retries retries."
-  exit 1
+  echo "Failed to launch instance after $retries retries in $region"
+}
+
+DESTINATION_REGION=''
+
+try_launch_ec2_instance ()
+{
+  candidate_regions=$(.circleci/bin/getmodelregions \
+    --instance-type "$INSTANCE_TYPE" \
+    --create-security-group \
+    --create-key-pair)
+
+  echo
+  echo -e "Candidate regions:\n\n$candidate_regions\n"
+
+  if [[ "$candidate_regions" == '' ]]; then
+    echo "No regions available to launch instance of this instance type $INSTANCE_TYPE."
+    exit 1
+  fi
+
+  for region in $candidate_regions; do
+    IFS='|' read -r region az subnet_id security_group_ids key_pair_name instance_type <<< "$region"
+
+    launch_ec2_instance "$region" "$az" "$subnet_id" "$security_group_ids" "$key_pair_name" "$instance_type"
+
+    if [[ "$INSTANCE_ID" != '' ]] || [[ "$INSTANCE_ID" != *"InsufficientInstanceCapacity"* ]]; then
+      DESTINATION_REGION="$region"
+      break
+    fi
+  done
+
+  if [[ "$INSTANCE_ID" == '' ]] || [[ "$INSTANCE_ID" == *"InsufficientInstanceCapacity"* ]]; then
+    echo "Failed to launch instance in any region."
+    exit 1
+  fi
 }
 
 wait_for_instance_to_be_available ()
 {
-  region='us-east-1'
-
-  aws ec2 wait instance-status-ok --instance-ids "$1" --region "$region"
+  aws ec2 wait instance-status-ok --instance-ids "$1" --region "$DESTINATION_REGION"
 }
 
 fetch_ec2_instance_public_ip ()
 {
-  region='us-east-1'
-
-  aws ec2 describe-instances --region "$region" --instance-ids "$1" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text
+  aws ec2 describe-instances --region "$DESTINATION_REGION" --instance-ids "$1" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text
 }
 
 store_ec2_private_key ()
@@ -169,7 +204,7 @@ copy_model_from_ec2_instance ()
 
 terminate_ec2_instance ()
 {
-  aws ec2 terminate-instances --instance-ids "$1" --region 'us-east-1'
+  aws ec2 terminate-instances --instance-ids "$1" --region $DESTINATION_REGION
 }
 
 on_exit ()
@@ -193,9 +228,8 @@ else
   exit 0
 fi
 
+INSTANCE_TYPE=p3.8xlarge
 LATEST_AMI=$(fetch_latest_ami_image_id_by_name "FPO Training*")
-SUBNET_ID=$(fetch_subnet_by_cidr "10.0.104.0/24")
-SECURITY_GROUP_IDS=$(fetch_security_group_by_name "allow-ssh")
 KEY_PAIR_NAME=fpo-training
 MODEL_BUCKET_NAME=trade-tariff-models-382373577178
 ACCOUNT_ID=$(fetch_account_id)
@@ -204,16 +238,15 @@ SHA=$(git rev-parse --short HEAD)
 VERSION=$(cat search-config.toml | grep version | awk '{print $3}' | sed 's/"//g')
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-launch_ec2_instance
+try_launch_ec2_instance
 
 PUBLIC_IP=$(fetch_ec2_instance_public_ip "$INSTANCE_ID")
 
 echo "Launching EC2 instance with configuration..."
 echo
 echo "📀 AMI: $LATEST_AMI"
-echo "☎️📞Subnet ID: $SUBNET_ID"
+echo "🤖 Instance Type: $INSTANCE_TYPE"
 echo "☎️📞Public IP: $PUBLIC_IP"
-echo "🔓 Security Group IDs: $SECURITY_GROUP_IDS"
 echo "🔓 Key Pair Name: $KEY_PAIR_NAME"
 echo "💿 Model Bucket Name: $MODEL_BUCKET_NAME"
 echo "💻 Account ID: $ACCOUNT_ID"

--- a/.circleci/bin/copyami
+++ b/.circleci/bin/copyami
@@ -16,8 +16,6 @@ SOURCE_REGION=${2:-us-east-1}
 DESTINATION_REGION=$3
 OWNER=$(aws sts get-caller-identity --query Account --output text)
 
-echo "Copying AMI $SOURCE_AMI_ID from $SOURCE_REGION to $DESTINATION_REGION"
-
 fetch_source_ami_name() {
   aws ec2 describe-images \
     --region "$SOURCE_REGION" \
@@ -68,8 +66,10 @@ main() {
   SOURCE_AMI_NAME=$(fetch_source_ami_name)
   DESTINATION_AMI_ID=$(fetch_destination_ami_name_by_name "$SOURCE_AMI_NAME")
 
+
+
   if [ "$DESTINATION_AMI_ID" == None ]; then
-    echo "Copying AMI $SOURCE_AMI_NAME to $DESTINATION_REGION"
+    echo "Copying AMI $SOURCE_AMI_ID from $SOURCE_REGION to $DESTINATION_REGION"
     copy_ami "$SOURCE_AMI_NAME"
     wait_for_copy "$SOURCE_AMI_NAME"
     exit 0

--- a/.circleci/bin/copyami
+++ b/.circleci/bin/copyami
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o noclobber
+
+# This script will take a source region ami id and replicate the ami into
+# a destination region.
+#
+# If the destination region already has the ami, the script will exit with
+# a 0 status code confirming that this version of the AMI already exists and therefore does not need to be copied
+# Otherwise the script will copy the AMI to the destination region and exit with a 0 status code
+SOURCE_AMI_ID=$1
+SOURCE_REGION=${2:-us-east-1}
+DESTINATION_REGION=$3
+OWNER=$(aws sts get-caller-identity --query Account --output text)
+
+echo "Copying AMI $SOURCE_AMI_ID from $SOURCE_REGION to $DESTINATION_REGION"
+
+fetch_source_ami_name() {
+  aws ec2 describe-images \
+    --region "$SOURCE_REGION" \
+    --image-ids "$SOURCE_AMI_ID" \
+    --owner "$OWNER" \
+    --query 'Images[0].Name' \
+    --output text
+}
+
+fetch_destination_ami_name_by_name() {
+  aws ec2 describe-images \
+    --region "$DESTINATION_REGION" \
+    --filters "Name=name,Values=$1" \
+    --owner "$OWNER" \
+    --query 'Images[0].Name' \
+    --output text
+}
+
+fetch_destination_ami_status_by_name() {
+  aws ec2 describe-images \
+    --region "$DESTINATION_REGION" \
+    --filters "Name=name,Values=$1" \
+    --owner "$OWNER" \
+    --query 'Images[0].State' \
+    --output text
+}
+
+copy_ami() {
+  aws ec2 copy-image \
+    --source-image-id "$SOURCE_AMI_ID" \
+    --source-region "$SOURCE_REGION" \
+    --region "$DESTINATION_REGION" \
+    --name "$1"
+}
+
+wait_for_copy() {
+  local image_name=$1
+  local status="pending"
+  while [ "$status" != "available" ]; do
+    echo "AMI $image_name is $status in $DESTINATION_REGION"
+    echo "Waiting..."
+    sleep 30
+    status=$(fetch_destination_ami_status_by_name "$image_name")
+  done
+}
+
+main() {
+  SOURCE_AMI_NAME=$(fetch_source_ami_name)
+  DESTINATION_AMI_ID=$(fetch_destination_ami_name_by_name "$SOURCE_AMI_NAME")
+
+  if [ "$DESTINATION_AMI_ID" == None ]; then
+    echo "Copying AMI $SOURCE_AMI_NAME to $DESTINATION_REGION"
+    copy_ami "$SOURCE_AMI_NAME"
+    wait_for_copy "$SOURCE_AMI_NAME"
+    exit 0
+  else
+    echo "AMI $SOURCE_AMI_NAME already exists in $DESTINATION_REGION"
+    exit 0
+  fi
+}
+
+USAGE="Usage: $0 <source-ami-id> <source-region> <destination-region>"
+
+if [ "$SOURCE_AMI_ID" = "" ]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+if [ "$SOURCE_REGION" = "" ]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+if [ "$DESTINATION_REGION" = "" ]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+main

--- a/.circleci/bin/getmodelregions
+++ b/.circleci/bin/getmodelregions
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "" ] || set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o noclobber
+
+USAGE=$(cat <<EOF
+Usage: $0 OPTIONS
+
+Fetches the regions that support the given instance type.
+
+Options:
+
+  Searches for a region that supports the instance type.
+
+  The output is a pipe-delimited list of regions, availability zones, subnet ids, security group ids and a key pair name that can be used to SSH into the instances.
+
+    --instance-type <instance-type> - The instance type to search for
+    --try-region-count <search-region-count> - The number of regions to search. Default is 5.
+    --create-security-group - Create a security group that allows SSH traffic from anywhere
+    --create-key-pair - Copy the fpo-training key to a region-specific key pair that can be used to SSH into instances
+
+    -h, --help - Show this help message
+
+Example:
+
+  $0 --instance-type t2.micro
+EOF
+)
+INSTANCE_TYPE=""
+TRY_REGION_COUNT=5
+CREATE_SECURITY_GROUP="false"
+CREATE_KEY_PAIR="false"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --instance-type)
+      INSTANCE_TYPE="$2"
+      shift 2
+      ;;
+    --try-region-count)
+      TRY_REGION_COUNT="$2"
+      shift 2
+      ;;
+    --create-security-group)
+      CREATE_SECURITY_GROUP="true"
+      shift 1
+      ;;
+    --create-key-pair)
+      CREATE_KEY_PAIR="true"
+      shift 1
+      ;;
+    -h|--help)
+      echo "$USAGE"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$INSTANCE_TYPE" = "" ]; then
+  echo "Instance type is required"
+  echo "$USAGE"
+  exit 1
+fi
+
+fetch_regions() {
+  aws ec2 describe-regions \
+    --query 'Regions[].RegionName' \
+    --output text \
+    | tr '\t' '\n' \
+    | head -n "$TRY_REGION_COUNT" \
+    | sed 's/\n/\t/'
+}
+
+fetch_regions_that_support_instance_type() {
+  for region in $(fetch_regions); do
+    if fetch_instance_type_location "$region"; then
+      az=$(fetch_availability_zones "$region")
+      subnet_ids=$(fetch_subnet_ids_in_default_vpc "$region" "$az")
+      security_group_id=$(find_or_create_security_group "$region")
+      key_pair_name=$(find_or_import_key_pair "$region")
+
+      echo "$region|$az|$subnet_ids|$security_group_id|$key_pair_name|$INSTANCE_TYPE"
+    fi
+  done
+}
+
+fetch_instance_type_location() {
+  region=$1
+  aws ec2 describe-instance-type-offerings \
+    --location-type region \
+    --filters Name=instance-type,Values="$INSTANCE_TYPE" \
+    --region "$region" \
+    --query 'InstanceTypeOfferings[].Location' \
+    --output text \
+    | grep -q "$region"
+}
+
+fetch_availability_zones() {
+  region=$1
+  aws ec2 describe-instance-type-offerings \
+    --location-type availability-zone \
+    --filters Name=instance-type,Values="$INSTANCE_TYPE" \
+    --region "$region" \
+    --query 'InstanceTypeOfferings[].Location' \
+    --output text \
+    | tr '\t' '\n' | head -1 | sed 's/\n//'
+}
+
+fetch_subnet_ids_in_default_vpc() {
+  region=$1
+  az=$2
+
+  aws ec2 describe-subnets \
+    --region "$region" \
+    --query "Subnets[?AvailabilityZone=='$az'].SubnetId" \
+    --output text \
+    | tr '\t' '\n' | head -1 | sed 's/\n//'
+}
+
+fetch_security_groups() {
+  name="$1"
+  region=$2
+  default_vpc_id=$3
+
+  # Fetch security groups
+  group_id=$(aws ec2 describe-security-groups \
+    --region "$region" \
+    --filters "Name=vpc-id,Values=$default_vpc_id" "Name=group-name,Values=$name" \
+    --query 'SecurityGroups[].GroupId' \
+    --output text)
+
+  if [ "$group_id" = "" ]; then
+    echo "none"
+  else
+    echo "$group_id"
+  fi
+}
+
+fetch_default_vpc_id() {
+  region=$1
+  aws ec2 describe-vpcs \
+    --region "$region" \
+    --filters "Name=isDefault,Values=true" \
+    --query 'Vpcs[].VpcId' \
+    --output text
+}
+
+fetch_key_pair_by_name() {
+  region=$1
+  name="$2"
+  key_pair_name=$(aws ec2 describe-key-pairs \
+    --region "$region" \
+    --key-names "$name" \
+    --query 'KeyPairs[].KeyName' \
+    --output text 2>/dev/null)
+
+  if [ "$key_pair_name" = "" ]; then
+    echo "none"
+  else
+    echo "$key_pair_name"
+  fi
+}
+
+find_or_create_security_group() {
+  region=$1
+  name="Allow SSH ALL Traffic"
+  default_vpc_id=$(fetch_default_vpc_id "$region")
+  security_group_id=$(fetch_security_groups "$name" "$region" "$default_vpc_id")
+
+  if [ "$CREATE_SECURITY_GROUP" == "false" ]; then
+    echo "$security_group_id"
+    return
+  fi
+
+  if [ "$security_group_id" == "none" ]; then
+    security_group_id=$(aws ec2 create-security-group \
+      --region "$region" \
+      --group-name "$name" \
+      --description "$name" \
+      --vpc-id "$default_vpc_id" \
+      --query 'GroupId' \
+      --output text)
+
+    aws ec2 authorize-security-group-ingress \
+      --region "$region" \
+      --group-id "$security_group_id" \
+      --protocol tcp \
+      --port 22 \
+      --cidr "0.0.0.0/0" \
+      --output text > /dev/null
+
+    echo "$security_group_id"
+  else
+    echo "$security_group_id"
+  fi
+}
+
+store_ec2_private_key () {
+  name=$1
+  source_key_region='eu-west-2'
+  pem_file=~/.ssh/"$name".pem
+  pem_pub_file=~/.ssh/"$name".pem.pub
+
+  if [ ! -f "$pem_file" ]; then
+    aws secretsmanager get-secret-value \
+      --secret-id "$name" \
+      --source_key_region "$source_key_region" \
+      --query 'SecretString' \
+      --output text > "$pem_file"
+
+    chmod 600 "$pem_file"
+  fi
+
+  if [ ! -f "$pem_pub_file" ]; then
+    ssh-keygen -y -f "$pem_file" > "$pem_pub_file"
+    chmod 644 "$pem_pub_file"
+
+    cat "$pem_pub_file" | base64 > "$pem_pub_file".base64
+  fi
+
+}
+
+find_or_import_key_pair() {
+  region=$1
+  name="fpo-training"
+  key_pair_name=$(fetch_key_pair_by_name "$region" "$name")
+
+  if [ "$CREATE_KEY_PAIR" == "false" ]; then
+    echo "$key_pair_name"
+    return
+  fi
+
+  if [ "$key_pair_name" == "none" ]; then
+    store_ec2_private_key "$name"
+
+    aws ec2 import-key-pair \
+      --region "$region" \
+      --key-name "$name" \
+      --public-key-material file://~/.ssh/"$name".pem.pub.base64 > /dev/null
+
+    echo "$name"
+  else
+    echo "$key_pair_name"
+  fi
+}
+
+fetch_regions_that_support_instance_type

--- a/.circleci/bin/getmodelregions
+++ b/.circleci/bin/getmodelregions
@@ -78,19 +78,6 @@ fetch_regions() {
     | sed 's/\n/\t/'
 }
 
-fetch_regions_that_support_instance_type() {
-  for region in $(fetch_regions); do
-    if fetch_instance_type_location "$region"; then
-      az=$(fetch_availability_zones "$region")
-      subnet_ids=$(fetch_subnet_ids_in_default_vpc "$region" "$az")
-      security_group_id=$(find_or_create_security_group "$region")
-      key_pair_name=$(find_or_import_key_pair "$region")
-
-      echo "$region|$az|$subnet_ids|$security_group_id|$key_pair_name|$INSTANCE_TYPE"
-    fi
-  done
-}
-
 fetch_instance_type_location() {
   region=$1
   aws ec2 describe-instance-type-offerings \
@@ -153,8 +140,10 @@ fetch_default_vpc_id() {
 }
 
 fetch_key_pair_by_name() {
-  region=$1
-  name="$2"
+  local region=$1
+  local name="$2"
+  local key_pair_name
+
   key_pair_name=$(aws ec2 describe-key-pairs \
     --region "$region" \
     --key-names "$name" \
@@ -169,17 +158,17 @@ fetch_key_pair_by_name() {
 }
 
 find_or_create_security_group() {
-  region=$1
-  name="Allow SSH ALL Traffic"
+  local region=$1
+  local name="Allow SSH ALL Traffic"
+  local default_vpc_id
+  local security_group_id
+
   default_vpc_id=$(fetch_default_vpc_id "$region")
   security_group_id=$(fetch_security_groups "$name" "$region" "$default_vpc_id")
 
   if [ "$CREATE_SECURITY_GROUP" == "false" ]; then
     echo "$security_group_id"
-    return
-  fi
-
-  if [ "$security_group_id" == "none" ]; then
+  elif [ "$security_group_id" == "none" ]; then
     security_group_id=$(aws ec2 create-security-group \
       --region "$region" \
       --group-name "$name" \
@@ -203,10 +192,10 @@ find_or_create_security_group() {
 }
 
 store_ec2_private_key () {
-  name=$1
-  source_key_region='eu-west-2'
-  pem_file=~/.ssh/"$name".pem
-  pem_pub_file=~/.ssh/"$name".pem.pub
+  local name=$1
+  local source_key_region='eu-west-2'
+  local pem_file=~/.ssh/"$name".pem
+  local pem_pub_file=~/.ssh/"$name".pem.pub
 
   if [ ! -f "$pem_file" ]; then
     aws secretsmanager get-secret-value \
@@ -228,16 +217,15 @@ store_ec2_private_key () {
 }
 
 find_or_import_key_pair() {
-  region=$1
-  name="fpo-training"
+  local region=$1
+  local name="fpo-training"
+  local key_pair_name
+
   key_pair_name=$(fetch_key_pair_by_name "$region" "$name")
 
   if [ "$CREATE_KEY_PAIR" == "false" ]; then
     echo "$key_pair_name"
-    return
-  fi
-
-  if [ "$key_pair_name" == "none" ]; then
+  elif [ "$key_pair_name" == "none" ]; then
     store_ec2_private_key "$name"
 
     aws ec2 import-key-pair \
@@ -251,4 +239,22 @@ find_or_import_key_pair() {
   fi
 }
 
-fetch_regions_that_support_instance_type
+main() {
+  for region in $(fetch_regions); do
+    if fetch_instance_type_location """$region"; then
+      local az
+      local subnet_ids
+      local security_group_id
+      local key_pair_name
+
+      az=$(fetch_availability_zones "$region")
+      subnet_ids=$(fetch_subnet_ids_in_default_vpc "$region" "$az")
+      security_group_id=$(find_or_create_security_group "$region")
+      key_pair_name=$(find_or_import_key_pair "$region")
+
+      echo "$region|$az|$subnet_ids|$security_group_id|$key_pair_name|$INSTANCE_TYPE"
+    fi
+  done
+}
+
+main

--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.5.1"
+version = "1.6.0"
 learning_rate = 0.0011
 max_epochs = 4
 model_batch_size = 1000
@@ -19,3 +19,6 @@ detected_languages = [ "ENGLISH", "FRENCH", "GERMAN", "SPANISH",]
 minimum_relative_distance = 0.7
 model_dropout_layer_1_percentage = 0.2
 model_dropout_layer_2_percentage = 0.5
+model_input_size = 768
+model_hidden_size = 8425
+model_output_size = 9764


### PR DESCRIPTION
### Jira link

FPO-404

### What?

I have added/removed/altered:

- [x] Adds script to enable copying amis into regions
- [x] Adds getmodelregions script
- [x] Alter the buildmodel script to train across multiple regions

### Why?

I am doing this because:

- This is a prerequisite for reducing insufficient capacity failures and to unblock training of our models

### AC

- Termination still works cleanly
- We've unblocked insufficient capacity failures
