### PR TITLE
BAU: Fixes remote docker arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,7 @@ jobs:
         type: string
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.11
-          docker_layer_caching: false
+      - setup_remote_docker
       - aws-cli/install
       - attach_workspace:
           at: .
@@ -172,9 +170,7 @@ jobs:
     executor: base
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.11
-          docker_layer_caching: false
+      - setup_remote_docker
       - aws-cli/install
       - run:
           name: "Build AMI"


### PR DESCRIPTION
### Jira link

### What?

I have added/removed/altered:

- Fix docker deprecation warning

### Why?

I am doing this because:

- The layer caching being off is the default
- The version we were referencing is deprecated
- Docker has a fairly stable api so lets just autoupdate
