### PR TITLE
FPO-419: Adds automated model build workflow

### DIFF
--- a/.circleci/bin/closepr
+++ b/.circleci/bin/closepr
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+[[ "$TRACE" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+close_pr() {
+  gh pr close "$CIRCLE_PULL_REQUEST"
+}
+
+delete_branch() {
+  git push origin --delete "$CIRCLE_BRANCH"
+}
+
+main() {
+  .circleci/bin/configuregit
+  close_pr
+  delete_branch
+}
+
+main

--- a/.circleci/bin/configuregit
+++ b/.circleci/bin/configuregit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+[[ "$TRACE" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+git config --global user.email "noreply@trade-tariff.service.gov.uk"
+git config --global user.name "trade-tariff-bot"

--- a/.circleci/bin/createpr
+++ b/.circleci/bin/createpr
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+[[ "$TRACE" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+EPOCH=$(date +%s)
+
+update_patch_version() {
+  local raw_current_version
+  local current_version
+  local current_major_version
+  local current_minor_version
+  local current_patch_version
+  local new_patch_version
+  local new_version
+
+  raw_current_version=$(cat search-config.toml | grep version)
+  current_version=$(cat search-config.toml | grep version | cut -d= -f2 | tr -d "[:space:]" | tr -d '"')
+  current_major_version=$(echo $current_version | cut -d. -f1)
+  current_minor_version=$(echo $current_version | cut -d. -f2)
+  current_patch_version=$(echo $current_version | cut -d. -f3)
+  new_patch_version=$((current_patch_version + 1))
+  new_version=$(echo "$current_major_version.$current_minor_version.$new_patch_version")
+
+  sed -i "s/$raw_current_version/version = \"$new_version\"/g" search-config.toml
+}
+
+get_branch_name() {
+  echo "automated-model-run-$EPOCH"
+}
+
+get_model_version() {
+  echo "$(cat search-config.toml | grep version | cut -d= -f2 | tr -d "[:space:]" | tr -d '"')"
+}
+
+checkout_new_branch() {
+  git checkout -b "$(get_branch_name)"
+}
+
+stage_commit_and_push_changes() {
+  git add search-config.toml
+  git commit -m "BAU: Automated model run $EPOCH."
+  git push origin "$(get_branch_name)"
+}
+
+open_pr() {
+  local title
+  local description
+  local base_branch="main"
+  local branch_name
+
+  title="🔄 BAU: Automated model run updated to model version $(get_model_version)"
+  description=$(
+    cat <<EOF
+# Automated Model Run ${EPOCH}
+
+🚀 **What's happening?**
+
+This automated model run has been initiated to incorporate any new data added to the model via the training pipeline's dynamic data sources.
+
+🔔 **Note:**
+This pull request will be **closed automatically** once the model run is complete.
+
+Thank you for your patience! 🙌
+EOF
+  )
+  branch_name=$(get_branch_name)
+
+  gh pr create --title "$title" --body "$description" --base "$base_branch" --head "$branch_name"
+}
+
+tag_branch() {
+  local tag_name
+  local tag_description
+
+  tag_name=$(get_branch_name)-$(get_model_version)
+  tag_description="BAU: Automated model run bumping model to $(get_model_version) on $EPOCH."
+
+  git tag -a $tag_name -m "$tag_description"
+  git push origin $tag_name
+}
+
+main() {
+  update_patch_version
+  checkout_new_branch
+  stage_commit_and_push_changes
+  open_pr
+  tag_branch
+}
+
+main

--- a/.circleci/bin/createpr
+++ b/.circleci/bin/createpr
@@ -7,11 +7,6 @@ set -o pipefail
 
 EPOCH=$(date +%s)
 
-configure_git() {
-  git config --global user.email "noreply@trade-tariff.service.gov.uk"
-  git config --global user.name "trade-tariff-bot"
-}
-
 update_patch_version() {
   local raw_current_version
   local current_version
@@ -88,7 +83,7 @@ tag_branch() {
 }
 
 main() {
-  configure_git
+  .circleci/bin/configuregit
   update_patch_version
   checkout_new_branch
   stage_commit_and_push_changes

--- a/.circleci/bin/createpr
+++ b/.circleci/bin/createpr
@@ -7,6 +7,11 @@ set -o pipefail
 
 EPOCH=$(date +%s)
 
+configure_git() {
+  git config --global user.email "noreply@trade-tariff.service.gov.uk"
+  git config --global user.name "trade-tariff-bot"
+}
+
 update_patch_version() {
   local raw_current_version
   local current_version
@@ -83,6 +88,7 @@ tag_branch() {
 }
 
 main() {
+  configure_git
   update_patch_version
   checkout_new_branch
   stage_commit_and_push_changes

--- a/.circleci/bin/fetchmodel
+++ b/.circleci/bin/fetchmodel
@@ -11,6 +11,8 @@ MODEL_KEY=$(.circleci/bin/getmodel)
 VERSION_PREFIX=$(echo "$MODEL_KEY" | awk -F/ '{print $1}')
 MODEL_BUCKET_NAME=trade-tariff-models-382373577178
 
+source .circleci/bin/isautomatedbuild
+
 if [ "$MODEL_KEY" = "" ]; then
   echo "No model for current version found"
   exit 1
@@ -23,6 +25,12 @@ validate_model() {
     echo "Model $MODEL_KEY has not passed validation"
     aws s3 cp --quiet "s3://$MODEL_BUCKET_NAME/$VERSION_PREFIX/failed" . && {
       echo "Model $MODEL_KEY is marked as failed"
+
+      if is_automated_build; then
+        echo "Automated build, closing PR"
+
+        .circleci/bin/closepr
+      fi
       exit 1
     }
     exit 1
@@ -51,7 +59,7 @@ mark_environment() {
 store_version() {
   echo "Storing version $VERSION_PREFIX"
   rm -f MODEL_VERSION
-  echo "$VERSION_PREFIX" > MODEL_VERSION
+  echo "$VERSION_PREFIX" >MODEL_VERSION
 }
 
 validate_model

--- a/.circleci/bin/ghinstall
+++ b/.circleci/bin/ghinstall
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+apt-get install dirmngr
+
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+sudo apt update
+sudo apt install gh

--- a/.circleci/bin/ghinstall
+++ b/.circleci/bin/ghinstall
@@ -12,3 +12,10 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githu
 
 sudo apt update
 sudo apt install gh
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "GITHUB_TOKEN is not set"
+  exit 1
+fi
+
+echo "${GITHUB_TOKEN}" | env -u GITHUB_TOKEN gh auth login --with-token --hostname github.com

--- a/.circleci/bin/ghinstall
+++ b/.circleci/bin/ghinstall
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-apt-get install dirmngr
+sudo apt-get install dirmngr
 
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
 

--- a/.circleci/bin/isautomatedbuild
+++ b/.circleci/bin/isautomatedbuild
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o noclobber
+
+get_current_head_tags() {
+  git tag --points-at HEAD
+}
+
+is_automated_build() {
+  if [[ "$(get_current_head_tags)" == *"automated-model-run"* ]]; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/.circleci/bin/mergepr
+++ b/.circleci/bin/mergepr
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+[[ "$TRACE" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source .circleci/bin/isautomatedbuild
+
+merge_pr() {
+  gh pr merge "$CIRCLE_PULL_REQUEST"
+}
+
+main() {
+  .circleci/bin/configuregit
+
+  if is_automated_build; then
+    echo "Automated build, merging PR"
+
+    merge_pr
+  fi
+}
+
+main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,10 +393,10 @@ workflows:
           context: trade-tariff-fpo-models-development
 
   bi-weekly-automated-model-build:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 1,15 * *"    # 1st and 15th of every month at midnight UTC
-    #       <<: *filter-main
+    triggers:
+      - schedule:
+          cron: "0 0 1,15 * *"    # 1st and 15th of every month at midnight UTC
+          <<: *filter-main
     jobs:
       - automated-build-model:
           context: trade-tariff-fpo-models-development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,13 @@ jobs:
           command: .circleci/bin/buildami
           no_output_timeout: 30m
 
+  automated-build-model:
+    executor: base
+    steps:
+      - checkout
+      - run: ".circleci/bin/ghinstall"
+      - run: ".circleci/bin/createpr"
+
   build-model:
     executor: base
     steps:
@@ -367,4 +374,13 @@ workflows:
           <<: *filter-main
     jobs:
       - clear-model-instances:
+          context: trade-tariff-fpo-models-development
+
+  bi-weekly-automated-model-build:
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 1,15 * *"    # 1st and 15th of every month at midnight UTC
+    #       <<: *filter-main
+    jobs:
+      - automated-build-model:
           context: trade-tariff-fpo-models-development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,13 @@ jobs:
           name: "Clear Lingering Model Instances"
           command: .circleci/bin/clearinstances
 
+  merge-automated-model-pr:
+    executor: base
+    steps:
+      - checkout
+      - run: ".circleci/bin/ghinstall"
+      - run: ".circleci/bin/mergepr"
+
 workflows:
   version: 2
 
@@ -293,6 +300,15 @@ workflows:
           endpoint: https://search.dev.trade-tariff.service.gov.uk
           requires:
             - deploy-development
+          <<: *filter-not-main
+
+      - merge-automated-model-pr:
+          name: merge-automated-model-pr
+          context: trade-tariff-fpo-models-development
+          requires:
+            - smoketest-development
+            - e2etest-development
+            - perftest-development
           <<: *filter-not-main
 
   deploy-to-staging-and-production:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ distlib==0.3.8
 filelock==3.13.4
 fsspec==2024.3.1
 h11==0.14.0
-huggingface-hub==0.22.2
+huggingface-hub==0.25.2
 identify==2.5.35
 idna==3.7
 Jinja2==3.1.4

--- a/requirements_lambda.txt
+++ b/requirements_lambda.txt
@@ -1,6 +1,6 @@
 aws-lambda-powertools==2.28.1
 jmespath==1.0.1
 lingua-language-detector==2.0.2
-sentence-transformers==2.2.2
+sentence-transformers==2.6.1
 sentry-sdk==2.8.0
 toml==0.10.2


### PR DESCRIPTION
### Jira link

FPO-419

### What?

I have added/removed/altered:

- [x] Added a workflow to automate releasing a new model on the 1st and 15th of each month
- [x] Added a script to create the PR and bump the version
- [x] Added a script to install gh cli since there's no official orb to do this
- [x] When validation of the model fails, make sure to close the PR, delete the branch and exit
- [x] When the validation succeeds and after post-deployment tests merge the PR to enable automated production deployments

### Why?

I am doing this because:

- This enables us to continually keep search references, commodities, etc, dynamically updated

### AC

- Models are successfully being generated on a schedule
- Automated PRs are closed off (either merged/closed and deleted) when we know the result
