### PR TITLE
Update model version for new tradestats data

### DIFF
--- a/.circleci/bin/getversions
+++ b/.circleci/bin/getversions
@@ -39,7 +39,7 @@ function get_latest_versions() {
       for (version in latest) {
           print latest[version]
       }
-  }' | sort
+  }' | sort -V
 }
 
 get_latest_versions | tail -n "$NUMBER_OF_VERSIONS"

--- a/.circleci/bin/needsmodel
+++ b/.circleci/bin/needsmodel
@@ -8,7 +8,7 @@ set -o noclobber
 needsmodel ()
 {
   versions_unsorted=$(git --no-pager diff main search-config.toml | grep version | sed 's/^[+|-]//g')
-  versions_sorted=$(git --no-pager diff main search-config.toml | grep version | sed 's/^[+|-]//g' | sort)
+  versions_sorted=$(git --no-pager diff main search-config.toml | grep version | sed 's/^[+|-]//g' | sort -V)
 
   # No change to versions
   if [[ -z "$versions_unsorted" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,11 +392,11 @@ workflows:
       - clear-model-instances:
           context: trade-tariff-fpo-models-development
 
-  bi-weekly-automated-model-build:
-    triggers:
-      - schedule:
-          cron: "0 0 1,15 * *"    # 1st and 15th of every month at midnight UTC
-          <<: *filter-main
-    jobs:
-      - automated-build-model:
-          context: trade-tariff-fpo-models-development
+  # bi-weekly-automated-model-build:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 0 1,15 * *"    # 1st and 15th of every month at midnight UTC
+  #         <<: *filter-main
+  #   jobs:
+  #     - automated-build-model:
+  #         context: trade-tariff-fpo-models-development

--- a/data_sources/commodities.py
+++ b/data_sources/commodities.py
@@ -37,10 +37,10 @@ class CommoditiesDataSource(DataSource):
         multiplier: int = 1,
     ):
         url = f"{self.HOST}{self.PATH}"
-        today = datetime.datetime.now()
-        year = str(today.year)
-        month = str(today.month).rjust(2, "0")
-        day = str(today.day).rjust(2, "0")
+        yesterday = datetime.datetime.today() - datetime.timedelta(days=1)
+        year = str(yesterday.year)
+        month = str(yesterday.month).rjust(2, "0")
+        day = str(yesterday.day).rjust(2, "0")
 
         url = (
             url.replace(":service", service)

--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.9.0"
+version = "1.10.0"
 learning_rate = 0.0011
 max_epochs = 4
 model_batch_size = 1024


### PR DESCRIPTION
### Jira link

### What?

I have added/removed/altered:

- [x] Fixed an issue with the model build numbers 10 or greater
- [x] Temporarily disabled the regular builds (we should review the plan for these)
- [x] Altered the commodities source to fetch yesterday's data in case this is running before the OTT CSV has been created

### Why?

I am doing this because:

- To update the model version to re-run the training with the latest tradestats data

