### PR TITLE
HMRC-111 | Handle missing req body in POST code search

### DIFF
--- a/aws_lambda/handler.py
+++ b/aws_lambda/handler.py
@@ -117,6 +117,11 @@ class LambdaHandler:
 
     @log_handler
     def handle_fpo_code_search_post(self, event, _context):
+        if not event.get("body"):
+            return {
+                "statusCode": 400,
+                "body": json.dumps({"error": "Request body is required"}),
+            }
         try:
             body = json.loads(event.get("body", {}))
         except json.JSONDecodeError as e:


### PR DESCRIPTION
### Jira link
[HMRC-111](https://transformuk.atlassian.net/browse/HMRC-111)

### What?

I have added/removed/altered:

- [ ] Added error handling for missing request body in POST code search

### Why?

I am doing this because:

- We want to handle bad request, not leave it for the catch all 500

### AC

- Instead of "TypeError: the JSON object must be str, bytes or bytearray, not NoneType" and a 500, we return error: "Request body is required" and a 400

<img width="709" alt="Screenshot 2025-02-06 at 11 43 28" src="https://github.com/user-attachments/assets/4c867457-d7e7-4655-b740-7b156d9784ae" />
