### PR TITLE
HMRC-695: Migrate model config into target

### DIFF
--- a/.circleci/bin/buildmodel
+++ b/.circleci/bin/buildmodel
@@ -226,7 +226,7 @@ run_benchmarks_on_ec2_instance() {
 copy_model_from_ec2_instance() {
   local s3_prefix="$VERSION-$SHA"
 
-  execute_command "$1" "cd $PROJECT && zip model.zip target/model.pt target/subheadings.pkl"
+  execute_command "$1" "cd $PROJECT && zip model.zip target/model.pt target/subheadings.pkl target/model.toml"
   scp -i ~/.ssh/"$KEY_PAIR_NAME".pem -o StrictHostKeyChecking=no ec2-user@"$1":~/"$PROJECT"/model.zip .
   scp -i ~/.ssh/"$KEY_PAIR_NAME".pem -o StrictHostKeyChecking=no ec2-user@"$1":~/"$PROJECT"/search-config.toml .
   aws s3 cp model.zip s3://"$MODEL_BUCKET_NAME/$s3_prefix/model.zip"

--- a/inference/infer.py
+++ b/inference/infer.py
@@ -1,6 +1,8 @@
 from logging import Logger
 import logging
 from math import floor
+
+import toml
 from aws_lambda_powertools import Logger as AWSLogger
 
 import numpy as np
@@ -142,15 +144,16 @@ class FlatClassifier(Classifier):
 
     def load_model(self):
         model_file = args.target_dir() / "model.pt"
+        model_config = toml.load(args.target_dir() / "model.toml")
 
         self._logger.info(f"💾⇨ Loading model file: {model_file}")
 
         model = SimpleNN(
-            args.model_input_size(),
-            args.model_hidden_size(),
-            args.model_output_size(),
-            args.model_dropout_layer_1_percentage(),
-            args.model_dropout_layer_2_percentage(),
+            model_config["input_size"],
+            model_config["hidden_size"],
+            model_config["output_size"],
+            model_config["dropout_layer_1_percentage"],
+            model_config["dropout_layer_2_percentage"],
         )
 
         try:

--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.11.0"
+version = "1.11.1"
 learning_rate = 0.0011
 max_epochs = 5
 model_batch_size = 1024

--- a/train.py
+++ b/train.py
@@ -215,12 +215,15 @@ if __name__ == "__main__":
     model_file = target_dir / "model.pt"
     torch.save(state_dict, model_file)
 
-    config = toml.load("search-config.toml")
-    config["model_input_size"] = input_size
-    config["model_hidden_size"] = hidden_size
-    config["model_output_size"] = output_size
+    model_config = {
+        "input_size": input_size,
+        "hidden_size": hidden_size,
+        "output_size": output_size,
+        "dropout_layer_1_percentage": args.model_dropout_layer_1_percentage(),
+        "dropout_layer_2_percentage": args.model_dropout_layer_2_percentage(),
+    }
 
-    with open("search-config.toml", "w") as f:
-        toml.dump(config, f)
+    with open("target/model.toml", "w") as f:
+        toml.dump(model_config, f)
 
     print("✅ Training complete. Enjoy your model!")


### PR DESCRIPTION
### Jira link

HMRC-695

### What?

I have added/removed/altered:

- [x] Migrate model config into target/

### Why?

I am doing this because:

- This enables clean loads of models without depending on search-config.toml
