### PR TITLE
BAU: Moves production notifications into the production-deployments channel

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -85,12 +85,13 @@ jobs:
   notify:
     needs: deploy
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
         with:
           result: ${{ needs.deploy.result }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: '#production-deployments'
 
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Silence skipped notifications
- [x] Put production notifications in the production-deployments slack channel

### Why?

I am doing this because:

- Mostly for consistency across the service but also just because these things create more signal and less noise
