### PR TITLE
HMRC-1163: Use a fined grained PAT

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -220,7 +220,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: gh pr merge ${{ github.event.pull_request.number }} --delete-branch --admin --merge --author-email "noreply@trade-tariff.service.gov.uk"
+      - run: gh pr merge ${{ github.event.pull_request.number }} --delete-branch --admin --merge
         env:
           GH_TOKEN: ${{ secrets.PULL_REQUEST_PAT }}
 


### PR DESCRIPTION
### Jira link

[HMRC-1163](https://transformuk.atlassian.net/browse/HMRC-1163)

### What?

I have added/removed/altered:

- [x] Added a PAT to each of the merge/close pr steps during model automation

### Why?

I am doing this because:

- This enables us to close and mergeprs since the permissions we would want aren't available in ephemeral github tokens
