### PR TITLE
HMRC-1415: Support additional vague terms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,13 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
+        exclude: reference_data/*
       - id: end-of-file-fixer
+        exclude: reference_data/*
       - id: check-yaml
+        exclude: reference_data/*
       - id: check-merge-conflict
+        exclude: reference_data/*
 
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.10.0

--- a/reference_data/vague_terms.csv
+++ b/reference_data/vague_terms.csv
@@ -233,3 +233,259 @@ collo
 CONSOLIDATED COLLI 12214529-1
 CONSOLIDATED COLLI 12207285-1
 consolidated colli
+1 box
+1 drum
+1 pallet 
+Access panels
+ACCESSORIES
+acoustic panels 
+acoustic screens
+adr
+aircraft parts
+aluminium 
+aluminium 
+aluminum
+ambient foodstuffs 
+arts
+artwork
+asdf
+Assorted 
+assorted hand tools 
+Assorted shopfittings 
+Audio Equipment 
+AUTO PARTS
+automotive components 
+automotive goods 
+automotive parts 
+Bathroom accessories
+bathroom equipment
+bathroom fittings
+bathroom goods
+Bathroom parts
+BLUE CENTRE FEED ROLLS
+Box 1 
+box x2
+boxes
+building products 
+building supplies
+bunding
+bus parts
+bus parts fabric
+CABLE
+cable & accessories
+cable kits 
+Cables
+car accessories 
+car parts 
+caravan accessories
+caravan parts
+cargo
+chemicals
+cleaning products
+cleaning solutions 
+CLOTHES
+CLOTHING
+coil
+commercial vehicle goods
+compressor parts
+computer parts 
+Construction fixings
+Construction materials
+Construction parts
+Construction products
+consumables 
+container 
+controls 
+crofters medley
+curatain tracks accessories 
+curtain accessories
+cylinders 
+ddp paharmaceuticals 
+decorating tools
+decorative materials 
+decorative products 
+default
+disability aid
+diy goods
+duty paid alcohol
+electric motor spare 
+electrical 
+electrical components 
+electrical enclosures 
+electrical goods 
+electrical machinery 
+electrical parts 
+electrical products 
+electrical supplies 
+enclosures 
+engine parts
+engineering components 
+engineering parts
+engineering products 
+fastener
+fire equipment
+fire fighting equipment
+fire supression equipment 
+fittings 
+flooring 
+floral  
+floral sundries 
+FOOD
+food - non poao
+food additives
+FOOD GOODS
+food ingredients 
+food packaging
+food stuffs
+foodstuff
+foodstuff
+Foodstuff
+Foodstuffs
+foot wear
+footwear
+footwear and accessories
+formers
+galvonised products 
+GARDEN PRODUCTS
+GARMENTS
+gate parts 
+general 
+general cargo
+general groupage 
+Gift sets
+GLASS
+glazing accessories 
+glazing parts 
+Goods
+GOODS-ASSORTED SHOPFITTINGS
+granules 
+hair and beauty products 
+hair dressing products 
+hair products 
+half load 
+hand tools 
+hardware 
+hardware parts
+haz
+haz goods 
+hazardous
+health & wellbeing products 
+heat recovery goods 
+homewares 
+horticultural products 
+HOUSEHOLD GOODS
+household items 
+housewares 
+hydraulic parts 
+hygeine packs 
+industrial parts 
+ingredients 
+items
+kitchen accessory
+kitchen appliances 
+laboritory equipment 
+life saving equipment 
+lighting equipment 
+load
+low voltage electrical goods 
+MACHINE PARTS
+MACHINE PARTS 
+Machinery
+machinery parts
+macweb
+mechanical goods 
+mechanical parts 
+media 
+medical devices 
+medical goods 
+medical parts
+medical supplies 
+Medicines
+Merchandise
+METAL
+metal fittings 
+metal fixings 
+metal goods 
+metal products 
+mild steel 
+mixed medical supplies 
+MIXED PHARMACEUTICALS AND MEDICAL SUPPLIES
+motor
+motor box
+motor parts 
+motor vehicle parts 
+new machine parts 
+new parts 
+No Bale Wood
+No bale(wood)
+non adr goods 
+non haz
+non-haz
+packaging 
+packs 
+pallet
+Pallets
+part
+PARTS
+PARTS 
+party
+partys
+pharma 
+pharmaceutical product
+pharmaceutical products
+Pharmaceuticals 
+pharmaceuticals 
+Pipes
+PLASTIC
+plastic and articles 
+plastic parts
+plastic plumbing parts 
+plastics 
+plumbing fittings 
+plumbing parts 
+pods 
+poles 
+POULTRY GOODS
+PPE
+refrigeration
+refrigeration parts 
+rollers 
+roofing materials
+roofing products
+rubber 
+sample packaging 
+samples 
+security accessories 
+security products 
+SHOES
+shopfittings 
+spare parts
+Spare Parts
+spare parts 
+spares 
+SPORTING GOODS
+stackable pallets 
+stationary 
+steel 
+STILLAGES
+stock 
+storage
+sundires
+SUPPLIES
+teroson
+test  
+Test equipment
+TEXTILES
+Tools
+tools and accessories 
+Toys
+track
+truck and trailor parts 
+truck parts 
+VARIOUS
+vehicle parts 
+ventilation equipment 
+vet supplies 
+welding consumables 
+wholesale textiles 
+workware 

--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.11.7"
+version = "1.12.0"
 learning_rate = 0.0011
 max_epochs = 5
 model_batch_size = 1024


### PR DESCRIPTION
### Jira link

[HMRC-1415](https://transformuk.atlassian.net/browse/HMRC-1415)

### What?

I have added/removed/altered:

- [x] Added support for additional vague terms

### Why?

I am doing this because:

- These have been identified by HMRC as being too vague to be useful for the search engine
