### PR TITLE
HMRC-1515: Extend vague terms support

### DIFF
--- a/aws_lambda/handler.py
+++ b/aws_lambda/handler.py
@@ -1,11 +1,13 @@
 import json
+import logging
+import time
 from typing import Union
 
 import aws_lambda_powertools
 
-from inference.infer import Classifier, ClassificationResult
 from data_sources.search_references import SearchReferencesDataSource
 from data_sources.vague_terms import VagueTermsCSVDataSource
+from inference.infer import ClassificationResult, Classifier
 from train_args import TrainScriptArgsParser
 from training.cleaning_pipeline import (
     CleaningPipeline,
@@ -16,9 +18,6 @@ from training.cleaning_pipeline import (
     RemoveShortDescription,
     StripExcessCharacters,
 )
-
-import logging
-import time
 
 with open("REVISION", "r") as f:
     REVISION = f.read().strip()
@@ -92,7 +91,10 @@ class LambdaHandler:
         self._classifier = classifier
         self._logger = logger
         self._search_references = SearchReferencesDataSource.build_from_json()
-        self._vague_terms = VagueTermsCSVDataSource(args.vague_terms_data_file())
+        self._vague_terms = VagueTermsCSVDataSource(
+            args.vague_terms_data_file(),
+            args.vague_terms_regex_file(),
+        )
 
     def handle(self, event, _context):
         if isinstance(self._logger, aws_lambda_powertools.Logger):

--- a/data_sources/vague_terms.py
+++ b/data_sources/vague_terms.py
@@ -1,6 +1,9 @@
 import csv
+import os
+import re
 from os import PathLike
 from typing import Union
+
 from data_sources.data_source import DataSource
 from inference.infer import vague_term_code
 
@@ -9,6 +12,7 @@ class VagueTermsCSVDataSource(DataSource):
     def __init__(
         self,
         filename: Union[str, PathLike],
+        patterns_file: Union[str, PathLike],
         encoding: str = "utf-8",
         authoritative: bool = True,
         creates_codes: bool = True,
@@ -21,8 +25,10 @@ class VagueTermsCSVDataSource(DataSource):
             multiplier=multiplier,
         )
         self._filename = filename
+        self._patterns_file = patterns_file
         self._encoding = encoding
-        self._codes: dict[str, set[str]] | None = None
+        self._codes: dict[str, set[str]] = {}
+        self._patterns: list[re.Pattern] = []
 
     def get_codes(self, digits: int) -> dict[str, set[str]]:
         with open(self._filename, mode="r", encoding=self._encoding) as csv_file:
@@ -30,25 +36,42 @@ class VagueTermsCSVDataSource(DataSource):
             next(csv_reader)
             code_data = list(csv_reader)
 
-        codes = {}
-
         for line in code_data:
             description = line[0].strip().lower()
 
-            if vague_term_code in codes:
-                codes[vague_term_code].add(description)
+            if vague_term_code in self._codes:
+                self._codes[vague_term_code].add(description)
             else:
-                codes[vague_term_code] = {description}
+                self._codes[vague_term_code] = {description}
 
-        self._codes = codes
+        return self._codes
 
-        return codes
+    def get_patterns(self) -> None:
+        if os.path.exists(self._patterns_file):
+            with open(self._patterns_file, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        try:
+                            self._patterns.append(re.compile(line, re.IGNORECASE))
+                        except re.error:
+                            print(
+                                f"Warning: Invalid regex in {self._patterns_file}: {line}"
+                            )
 
     def includes_description(self, description) -> bool:
-        if self._codes is None:
+        description = description.strip().lower()
+
+        if not self._codes:
             self.get_codes(0)
 
-        if self._codes:
-            return description.strip().lower() in self._codes[vague_term_code]
-        else:
-            return False
+        if not self._patterns:
+            self.get_patterns()
+
+        if description in self._codes[vague_term_code]:
+            return True
+
+        if any(pattern.match(description) for pattern in self._patterns):
+            return True
+
+        return False

--- a/reference_data/vague_terms.csv
+++ b/reference_data/vague_terms.csv
@@ -1,21 +1,4 @@
 (not eu pref. orig.) decal
-[bn-00382-100w30h-banner_nw] p
-[bn-00382-133w40h-banner_nw] p
-[bn-00385-166w50h-banner_nw] p
-[bn-00385-166w50h-banner_vy] p
-[bn-00864-166w50h-banner_nw] p
-[bn-00897-166w50h-banner_nw] p
-[bn-00930-133w40h-banner_vy] p
-[bn-01017-100w30h-banner_nw] p
-[bn-01042-133w40h-banner_nw] p
-[bn-01062-100w30h-banner_nw] p
-[bn-01062-166w50h-banner_nw] p
-[bn-01067-100w30h-banner_nw] p
-[bn-01184-133w40h-banner_vy] p
-[bn-02039-100w30h-banner_nw] p
-[bn-02256-166w50h-banner_nw] p
-[bn-02347-200w60h-banner_vy] p
-[bn-03159-100w30h-banner_nw] c
 0
 0
 1
@@ -28,71 +11,336 @@
 1-1/2 X 2 X 1/4 X 3/8
 1-3/4 X 1/2 X .075/.080
 1x dark
+1x default
+1x ultra dark
+2 pack
+25 ttl eye lift a4 hldrs 1=1
+ACCESSORIES
+AUTO PARTS
+AWB/ HAWB
 Access panels
 Accessories
-ACCESSORIES
-acoustic panels 
-acoustic screens
 Adapter
-adapters
-adr
-æ
 Agricultural products
-aircraft parts
 Alcohol
 All kind of Goods
-all kinds of goods
-aluminium 
-aluminium 
-aluminum
-ambient foodstuffs 
 Animals
-anua hrtlf qrctnl pre dp clnsn
 Apparel
 Appliances
 Arms
 Articles
-arts
-artwork
 Artwork
-artworks
-as ordered
 As ordered […]
 As per attached [invoice]
-asdf
 Assorted 
-assorted hand tools 
 Assorted shopfittings 
 Attached [manifest]
 Audio Equipment 
 Auto Parts
-AUTO PARTS
-automotive components 
-automotive goods 
-automotive parts 
-AWB/ HAWB
+BLUE CENTRE FEED ROLLS
 Baggage
 Bags (or other types of
-banner
 Bathroom accessories
-bathroom equipment
-bathroom fittings
-bathroom goods
 Bathroom parts
 Battery
 Bazaar goods
 Biological Substances
 Birthday gifts
 Bits
+Boards
+Box
+Box 1 
+CABLE
+CLOTHES
+CLOTHING
+CONSOLIDATED COLLI 12207285-1
+CONSOLIDATED COLLI 12214529-1
+Cables
+Cables
+Caps
+Cartons, CTN
+Case
+Charity
+Chemicals
+Chemicals, flammable
+Chemicals, hazardous
+Chemicals, non-Hazardous
+Christmas gift
+Cleaning products
+Clothes
+Clothing
+Collected items
+Commodity
+Company names
+Component
+Consol, CON, CNSL
+Consolidated
+Consolidated cargo
+Consolidated goods
+Consolidation
+Construction fixings
+Construction materials
+Construction parts
+Construction products
+Consumer
+Courier
+Courier bags
+Courier goods
+Courier material
+Dangerous goods
+Decorations
+Decorative crafts
+Decorative items
+Didactic articles
+Documents, Documentations, Docs, Dox
+Drugs
+Drums
+Electronic equipment
+Electronic goods
+Electronic items
+Electronics
+Equipment, EQP
+Exhibition goods
+Express
+FOOD
+FOOD GOODS
+Firearm
+Fish
+Food
+Foodstuff
+Foodstuff
+Foodstuffs
+Footwear
+Fresh Fruit
+Fresh Herbs
+Fresh Plants
+Fresh Vegetable
+From UPU Postal
+Fruit
+Fruit Pulp
+Fruit products
+Fuel
+GARDEN PRODUCTS
+GARMENTS
+GLASS
+GOODS-ASSORTED SHOPFITTINGS
+Garments
+General goods
+General merchandise
+Gift box
+Gift not for resale
+Gift sets
+Gifts
+Gizmos
+Glass
+Goods
+Goods
+Goods, GDS
+Granulate
+HOUSEHOLD GOODS
+Handcraft
+Handicraft
+Handling codes
+Hardware for gift
+Herbs
+Home goods
+Household goods
+I.T. goods
+Instruments
+Invoice
+Iron, Steel
+Iso Tanks
+Jewellery, Jewelry
+Jewels
+Joint shipping
+Label
+Leather Articles
+Likewise
+Line
+Liquids, Fluids
+Live Animals
+Live plants
+MACHINE PARTS
+MACHINE PARTS 
+MDF
+METAL
+MIXED PHARMACEUTICALS AND MEDICAL SUPPLIES
+Machine parts
+Machinery
+Machinery
+Machines
+Mail
+Materials
+Meat
+Medical equipment
+Medicines
+Medicines
+Merchandise
+Merchandise, Merc.
+Metal
+Miscellaneous products, Misc, Mixed, Mix
+Model
+No Bale Wood
+No bale(wood)
+Non-Woven
+None
+Odd parts
+Others
+PARTS
+PARTS 
+PLASTIC
+PLASTIC
+POULTRY GOODS
+PPE
+PVC items
+Package numbers
+Pad
+Pallets
+Pallets, PLT
+Parcel
+Parts
+Party accessories
+Perishables
+Personal address
+Personal effects
+Pharmaceutical
+Pharmaceuticals 
+Pieces, pces
+Pipes
+Pipes
+Plants
+Plastic Goods
+Plates
+Polyurethane
+Powder
+Pre-addressed parcel
+Printed material
+Private things
+Produce
+Products
+Propellant
+Quilts
+Raw material
+Returned goods
+Rod
+Rubber Articles
+SHOES
+SPORTING GOODS
+STILLAGES
+SUPPLIES
+Said to Contain
+Sample
+Samples for analysis
+Sanitary goods
+Scrap
+See [invoice]
+See attached invoice
+Several
+Several goods
+Shoes
+Small goods
+Snickers
+Souvenirs
+Spare
+Spare Parts
+Spare parts, SPPT
+Sporting Goods
+Stuff
+Substance
+TEXTILES
+Tablet accessories
+Tablets
+Technology
+Test
+Test equipment
+Textile goods
+Textiles
+Things
+Tires
+Tools
+Tools
+Toys
+Toys
+Tubing
+Unacceptable words
+Uniform
+VARIOUS
+Vaccine
+Various
+Various goods
+Various products
+Vegetables
+Waste
+Weapons
+Wearing apparel
+White goods
+Wires
+Wooden articles
+X mas gift
+Xmas gift
+[bn-00011-166w50h-banner_vy] p
+[bn-00012-133w40h-banner_nw] p
+[bn-00382-100w30h-banner_nw] p
+[bn-00382-133w40h-banner_nw] p
+[bn-00385-166w50h-banner_nw] p
+[bn-00385-166w50h-banner_vy] p
+[bn-00401-166w50h-banner_vy] p
+[bn-00417-166w50h-banner_nw] p
+[bn-00864-166w50h-banner_nw] p
+[bn-00897-166w50h-banner_nw] p
+[bn-00930-133w40h-banner_vy] p
+[bn-01017-100w30h-banner_nw] p
+[bn-01037-100w30h-banner_nw] p
+[bn-01042-133w40h-banner_nw] p
+[bn-01062-100w30h-banner_nw] p
+[bn-01062-133w40h-banner_nw] p
+[bn-01062-166w50h-banner_nw] p
+[bn-01067-100w30h-banner_nw] p
+[bn-01072-100w30h-banner_nw] p
+[bn-01153-166w50h-banner_vy] p
+[bn-01184-133w40h-banner_vy] p
+[bn-01689-233w70h-banner_nw] p
+[bn-02039-100w30h-banner_nw] p
+[bn-02256-166w50h-banner_nw] p
+[bn-02347-200w60h-banner_vy] p
+[bn-02709-166w50h-banner_vy] p
+[bn-02840-102w60h-banner_nw] p
+[bn-02932-119w70h-banner_vy] p
+[bn-02972-266w80h-banner_vy] p
+[bn-03159-100w30h-banner_nw] c
+[bn-03174-100w30h-banner_vy] p
+acoustic panels 
+acoustic screens
+adapters
+adr
+aircraft parts
+all kinds of goods
+aluminium 
+aluminium 
+aluminum
+ambient foodstuffs 
+anua hrtlf qrctnl pre dp clnsn
+arts
+artwork
+artworks
+as ordered
+asdf
+assorted hand tools 
+authentic science fiction mont
+automotive components 
+automotive goods 
+automotive parts 
+b2c direct to customer
+banner
+bathroom equipment
+bathroom fittings
+bathroom goods
+black
 black
 blue
-BLUE CENTRE FEED ROLLS
-Boards
 boj glw dp srm rice alpha arbu
 bookmark
 boots festival edit
-Box
-Box 1 
 box x2
 boxes
 bts kds click clacks spts stri
@@ -103,93 +351,60 @@ bunding
 bus parts
 bus parts fabric
 cable
-CABLE
 cable & accessories
 cable kits 
-Cables
-Cables
-Caps
 car accessories 
 car parts 
 caravan accessories
 caravan parts
+care
 cargo
-Cartons, CTN
-Case
-Charity
 chemicals
-Chemicals
-Chemicals, flammable
-Chemicals, hazardous
-Chemicals, non-Hazardous
-Christmas gift
+clairl clr std stp1 prmr pr-cl
+clctn ibl brw glu xtra strng s
+clctn lp uc cnclr sh4w ex f wr
 cleaning products
-Cleaning products
 cleaning solutions 
-Clothes
-CLOTHES
+clinhiimpactmasc black
 clothesclothes
-Clothing
-CLOTHING
+clothing/accessories
+clrl clr strg prmnt-1.0 blck
 coasters
 coil
 collec glw filtr fin prm & ilu
-Collected items
 colli
 collo
 colour collection insert
 commercial vehicle goods
 commodities not specified according to kind
-Commodity
 common goods
-Company names
-Component
 components
 compressor parts
 computer parts 
-Consol, CON, CNSL
-Consolidated
-Consolidated cargo
 consolidated colli
-CONSOLIDATED COLLI 12207285-1
-CONSOLIDATED COLLI 12214529-1
-Consolidated goods
-Consolidation
-Construction fixings
-Construction materials
-Construction parts
-Construction products
 consumables 
-Consumer
+cont white 7pk /080
 container 
 controls 
-Courier
-Courier bags
-Courier goods
-Courier material
+cool nose pass
+craft
 crofters medley
 curatain tracks accessories 
 curtain accessories
 cylinders 
-Dangerous goods
 dd
 ddp paharmaceuticals 
 decorating tools
-Decorations
-Decorative crafts
-Decorative items
 decorative materials 
 decorative products 
 default
 destination set eu int
-Didactic articles
 disability aid
+divchi 2x set of anti-slip rec
 diverse
 diy goods
-Documents, Documentations, Docs, Dox
 double
-Drugs
-Drums
+duo box
 duty paid alcohol
 e-Commerce
 electric motor spare 
@@ -202,90 +417,50 @@ electrical parts
 electrical products 
 electrical supplies 
 electronic
-Electronic equipment
-Electronic goods
-Electronic items
-Electronics
 enclosures 
 engine parts
 engineering components 
 engineering parts
 engineering products 
-Equipment, EQP
-Exhibition goods
-Express
 fashion
 fastener
 filter
 fire equipment
 fire fighting equipment
 fire supression equipment 
-Firearm
 firearms
-Fish
 fittings 
 fixer
 flooring 
 floral  
 floral sundries 
-Food
-FOOD
 food - non poao
 food additives
-FOOD GOODS
 food ingredients 
 food item
 food packaging
 food stuffs
 foodstuff
 foodstuff
-Foodstuff
-Foodstuff
-Foodstuffs
 foot wear
 footwear
-Footwear
 footwear and accessories
 formers
-Fresh Fruit
-Fresh Herbs
-Fresh Plants
-Fresh Vegetable
+free gift
 fresh vegetables
-From UPU Postal
-Fruit
-Fruit products
-Fruit Pulp
-Fuel
+fun uniform
 fx
 galvonised products 
-GARDEN PRODUCTS
-Garments
-GARMENTS
 gate parts 
 general 
 general cargo
-General goods
 general groupage 
 general hscode
-General merchandise
 gift
 gift  no commercial value
-Gift box
-Gift not for resale
 gift pack
-Gift sets
-Gifts
-Gizmos
-Glass
-GLASS
 glazing accessories 
 glazing parts 
-Goods
-Goods
-GOODS-ASSORTED SHOPFITTINGS
-Goods, GDS
-Granulate
 granules 
 grey
 h&s pro expt dp cln ints frsh
@@ -294,280 +469,172 @@ hair dressing products
 hair products 
 half load 
 hand tools 
-Handcraft
-Handicraft
-Handling codes
 hardware 
-Hardware for gift
 hardware parts
 haz
 haz goods 
 hazardous
 health & wellbeing products 
 heat recovery goods 
-Herbs
+hello moto comp slip
 holder
-Home goods
+holder
+home decoration
+home wear
 homewares 
 horticultural products 
-Household goods
-HOUSEHOLD GOODS
 household items 
 housewares 
 hs codes as per attached documents
 hydraulic parts 
 hygeine packs 
 hype girls pink/turquoise past
-I.T. goods
+iframe s blk wd fin fram with
 industrial parts 
 ingredients 
-Instruments
-Invoice
-Iron, Steel
-Iso Tanks
 it - information technology
 item description
 item1
 items
-Jewellery, Jewelry
-Jewels
-Joint shipping
+king
 kitchen accessory
 kitchen appliances 
-Label
 laboritory equipment 
 le c+p 100ml tube
-Leather Articles
 life saving equipment 
 lighting equipment 
-Likewise
-Line
-Liquids, Fluids
-Live Animals
-Live plants
 load
 low voltage electrical goods 
-Machine parts
-MACHINE PARTS
-MACHINE PARTS 
-Machinery
-Machinery
+lp ls ns clr rch stn ls 173
+lrp anthls uv 400 inv fld tnt
 machinery parts
-Machines
 macweb
-Mail
 mandm standard unlimited membership
-Materials
-MDF
-Meat
 mechanical goods 
 mechanical parts 
 media 
 medical devices 
-Medical equipment
 medical goods 
 medical parts
 medical supplies 
-Medicines
-Medicines
-Merchandise
-Merchandise, Merc.
-Metal
-METAL
+men's casual wear
 metal fittings 
 metal fixings 
 metal goods 
 metal products 
 mf ce quck dry np i believe in
 mild steel 
-Miscellaneous products, Misc, Mixed, Mix
 mixed consumer goods
 mixed consumer goods
+mixed items
 mixed medical supplies 
-MIXED PHARMACEUTICALS AND MEDICAL SUPPLIES
-Model
 motor
 motor box
 motor parts 
 motor vehicle parts 
+movies & tv new tralalero tral
 na
 new machine parts 
 new parts 
-No Bale Wood
-No bale(wood)
 non adr goods 
 non haz
 non-haz
-Non-Woven
-None
+nuts
 ob vp e rech thbrh lilac
-Odd parts
 office - quotemywall 36 stick
-Others
+office - quotemywall 84 stick
+office peripherals
+ornament
 p6709
 pack of 2
 pack of 4
-Package numbers
 packaging 
 packs 
-Pad
 pallet
-Pallets
-Pallets, PLT
-Parcel
 part
-Parts
-PARTS
-PARTS 
 party
-Party accessories
 partys
-Perishables
-Personal address
-Personal effects
 personal gift
+personal goods
 pharma 
-Pharmaceutical
 pharmaceutical product
 pharmaceutical products
 pharmaceuticals 
-Pharmaceuticals 
 phrama
-Pieces, pces
 pink
-Pipes
-Pipes
-Plants
-PLASTIC
-PLASTIC
 plastic and articles 
-Plastic Goods
 plastic parts
 plastic plumbing parts 
 plastics 
-Plates
 plumbing fittings 
 plumbing parts 
 pods 
 poles 
-Polyurethane
-POULTRY GOODS
-Powder
-PPE
-Pre-addressed parcel
 printed garment
-Printed material
-Private things
-Produce
-Products
-Propellant
 props for the show
 purchase
-PVC items
-Quilts
-Raw material
 refrigeration
 refrigeration parts 
 retail items
-Returned goods
-Rod
+rev hlt rlded hltr mke an impc
 rollers 
 roofing materials
 roofing products
+royal mail 24 tracked large le
 royal mail tracked 48h - retai
 rubber 
-Rubber Articles
 s hansn hd/nls clr/nylon
-Said to Contain
-Sample
 sample packaging 
 samples 
-Samples for analysis
-Sanitary goods
-Scrap
+sclptd b am lqd lghts r r b 7m
 security accessories 
 security products 
-See [invoice]
-See attached invoice
-Several
-Several goods
 shipping (shipped by seller)
 shipping charge
-Shoes
-SHOES
 shopfittings 
 sida
 sida1688
 sida19
+single
 sleeve set
-Small goods
-Snickers
-Souvenirs
-Spare
+sole house limited
+sp
+spaceduck
 spare parts
-Spare Parts
 spare parts 
-Spare parts, SPPT
 spares 
-Sporting Goods
-SPORTING GOODS
+splesh culina (tiktok spec)
 stackable pallets 
 stan adv 40oz
 stationary 
 steel 
-STILLAGES
 stock 
 storage
-Stuff
-Substance
+sub-box
 sundires
-SUPPLIES
-Tablet accessories
-Tablets
-Technology
 tee shirt
 teroson
-Test
 test  
-Test equipment
-Textile goods
-Textiles
-TEXTILES
+the doux crzysxycrl hny stng f
 these items were all placed on
-Things
-Tires
 tool / parts
-Tools
-Tools
 tools and accessories 
-Toys
-Toys
 track
 truck and trailor parts 
 truck parts 
-Tubing
-Unacceptable words
-Uniform
-Vaccine
-Various
-VARIOUS
-Various goods
-Various products
-Vegetables
 vehicle parts 
+vehicle parts/tools
 ventilation equipment 
 vet supplies 
-Waste
-Weapons
-Wearing apparel
 web order
+wedding accessories
 welding consumables 
-White goods
+white, pack of 2
 wholesale textiles 
-Wires
+women clothing
 women's clothing
-Wooden articles
 workware 
 workwear
-X mas gift
-Xmas gift
+ysh15000
+zhazhiji
+æ

--- a/reference_data/vague_terms_patterns.txt
+++ b/reference_data/vague_terms_patterns.txt
@@ -1,0 +1,2 @@
+# This pattern matches the following vague term but also all other variations that follow the same scheme '[bn-00011-166w50h-banner_vy] p'
+^\[bn-\d+-\d+w\d+h-banner_[a-z]{2}\] [a-z]$

--- a/search-config.toml
+++ b/search-config.toml
@@ -5,6 +5,7 @@ max_epochs = 5
 model_batch_size = 1024
 embedding_batch_size = 250
 vague_terms_data_file = "reference_data/vague_terms.csv"
+vague_terms_regex_file = "reference_data/vague_terms_patterns.txt"
 extra_data_file = "reference_data/extra_references.csv"
 cn_data_file = "reference_data/CN2025_SelfText_EN_DE_FR.csv"
 exact_english_terms = "reference_data/exact_english_terms.txt"

--- a/tests/aws_lambda/test_handler.py
+++ b/tests/aws_lambda/test_handler.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import unittest
-from aws_lambda.handler import LambdaHandler
 
+from aws_lambda.handler import LambdaHandler
 from inference.infer import ClassificationResult, Classifier
 
 logger = logging.getLogger()
@@ -59,6 +59,24 @@ class Test_handler_handle(unittest.TestCase):
 
     def test_it_should_handle_vague_terms(self):
         event = self._create_post_event("Bits", "6", "5")
+
+        result = handler.handle(event, {})
+        result_body = json.loads(result["body"])
+
+        self.assertEqual(200, result["statusCode"], "Expected a 200 status code")
+        self.assertEqual(
+            {"results": []},
+            result_body,
+            "Expected 1 result",
+        )
+        self.assertEqual(
+            "6b85ab53-2b60-4178-81ce-342acdec65a2",
+            result["headers"]["X-Request-Id"],
+            "Expected a request id",
+        )
+
+    def test_it_should_handle_vague_patterns(self):
+        event = self._create_post_event("[bn-00011-166w50h-banner_vy] z", "6", "5")
 
         result = handler.handle(event, {})
         result_body = json.loads(result["body"])

--- a/train.py
+++ b/train.py
@@ -1,18 +1,18 @@
 if __name__ == "__main__":
-    import toml
     import logging
     import pickle
-    import torch
-
     from pathlib import Path
 
+    import toml
+    import torch
+
+    from data_sources.basic_csv import BasicCSVDataSource
     from data_sources.commodities import CommoditiesDataSource
+    from data_sources.data_source import DataSource
+    from data_sources.search_references import SearchReferencesDataSource
+    from data_sources.vague_terms import VagueTermsCSVDataSource
     from train_args import TrainScriptArgsParser
     from training.cleaners.map_2024_to_2025_codes import Map2024CodesTo2025Codes
-    from training.prepare_data import TrainingDataLoader
-    from training.train_model import FlatClassifierModelTrainer
-    from training.create_embeddings import EmbeddingsProcessor
-
     from training.cleaning_pipeline import (
         CleaningPipeline,
         DescriptionLower,
@@ -27,11 +27,9 @@ if __name__ == "__main__":
         RemoveSubheadingsNotMatchingRegexes,
         StripExcessCharacters,
     )
-
-    from data_sources.vague_terms import VagueTermsCSVDataSource
-    from data_sources.search_references import SearchReferencesDataSource
-    from data_sources.data_source import DataSource
-    from data_sources.basic_csv import BasicCSVDataSource
+    from training.create_embeddings import EmbeddingsProcessor
+    from training.prepare_data import TrainingDataLoader
+    from training.train_model import FlatClassifierModelTrainer
 
     args = TrainScriptArgsParser()
     args.print()
@@ -110,7 +108,12 @@ if __name__ == "__main__":
 
     data_sources: list[DataSource] = []
 
-    data_sources.append(VagueTermsCSVDataSource(args.vague_terms_data_file()))
+    data_sources.append(
+        VagueTermsCSVDataSource(
+            args.vague_terms_data_file(),
+            args.vague_terms_regex_file(),
+        )
+    )
 
     data_sources.append(
         BasicCSVDataSource(

--- a/train_args.py
+++ b/train_args.py
@@ -1,8 +1,9 @@
 import argparse
-from pathlib import Path
-import torch
-import toml
 import logging
+from pathlib import Path
+
+import toml
+import torch
 
 logger = logging.getLogger("config")
 logging.basicConfig(level=logging.INFO)
@@ -85,6 +86,12 @@ class TrainScriptArgsParser:
             type=str,
             help="the path to the vague terms data file",
             default="reference_data/vague_terms.csv",
+        )
+        parser.add_argument(
+            "--vague-terms-regex-file",
+            type=str,
+            help="the path to the vague terms regex file. Add python regexes to this file, one per line that match on known vague terms.",
+            default="reference_data/vague_terms_regex.txt",
         )
         parser.add_argument(
             "--extra-references-data-file",
@@ -264,6 +271,10 @@ class TrainScriptArgsParser:
     @config_from_file
     def vague_terms_data_file(self):
         return self.parsed_args.vague_terms_data_file
+
+    @config_from_file
+    def vague_terms_regex_file(self):
+        return self.parsed_args.vague_terms_regex_file
 
     @config_from_file
     def limit(self):


### PR DESCRIPTION
### Jira link

[HMRC-1515](https://transformuk.atlassian.net/browse/HMRC-1515)

### What?

I have added/removed/altered:

- Adds some vague terms that were explicitly discovered in the wild
- Added a regex to match against vague terms in a more permissive way to reduce overheads
- Sort vague terms so they're easier to deal with

### Why?

I am doing this because:

- This is a requirement coming from HMRC
- This enables more flexible pattern matching on obviously vague things during inference and training

### AC

- Vague terms added
- Arbitrary combinations of vague patterns return early with empty results set
