### PR TITLE
HMRC-858: Updates model version to include new trade set data

### DIFF
--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.17.2"
+version = "1.18.0"
 learning_rate = 0.0011
 max_epochs = 5
 model_batch_size = 1024

--- a/search-config.toml
+++ b/search-config.toml
@@ -1,5 +1,5 @@
 name = "fpo-search-model-generator"
-version = "1.18.0"
+version = "1.18.1"
 learning_rate = 0.0011
 max_epochs = 5
 model_batch_size = 1024


### PR DESCRIPTION
### Jira link

[HMRC-857](https://transformuk.atlassian.net/browse/HMRC-857)
[HMRC-858](https://transformuk.atlassian.net/browse/HMRC-858)

### What?

I have added/removed/altered:

18.0 (drop in well described goods performance)

- [x] Added Jan 2025 tradeset data
- [x] Added Feb 2025 tradeset data
- [x] Removed 2023 tradeset data
- [x] Kept all of 2024 tradeset data

18.1 (mostly improvements across the board)

- [x] Added Jan 2025 tradeset data
- [x] Added Feb 2025 tradeset data

### Why?

I am doing this because:

- This is to bring us up to date with our classifications of subheadings
