### PR TITLE
HMRC-2184: Change prod log retention from 30 to 180 days

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -76,7 +76,7 @@ custom:
   logRetentionInDays:
     development: 7
     staging: 14
-    production: 30
+    production: 180
 
 resources:
   Resources:


### PR DESCRIPTION
### Jira link

[HMRC-2184](https://transformuk.atlassian.net/browse/HMRC-2184)
### What?

I have added/removed/altered:

- [x] Changed log retention from 30 to 180 days in production env

### Why?

I am doing this because:

- Longer log retention is required for improved debugging, auditing, and compliance purposes.

### AC

-
-
-
