### PR TITLE
HMRC-2189: Reduce noise from production alarms

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -97,8 +97,28 @@ resources:
             Value: ${self:service}-${env:STAGE}-fpo_search
         Statistic: Sum
         Period: 300 # 5 minutes
-        EvaluationPeriods: 1
-        Threshold: 1
+        EvaluationPeriods: 2
+        Threshold: 5
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        AlarmActions:
+          - arn:aws:sns:${self:provider.region}:${aws:accountId}:slack-topic
+        TreatMissingData: notBreaching
+
+    ApiGateway5xxAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmDescription: "Alarm if FPO search API Gateway 5xx responses exceed a threshold"
+        Namespace: "AWS/ApiGateway"
+        MetricName: "5XXError"
+        Dimensions:
+          - Name: "ApiName"
+            Value: ${self:service}-${env:STAGE}
+          - Name: "Stage"
+            Value: ${env:STAGE}
+        Statistic: Sum
+        Period: 300 # 5 minutes
+        EvaluationPeriods: 2
+        Threshold: 5
         ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - arn:aws:sns:${self:provider.region}:${aws:accountId}:slack-topic


### PR DESCRIPTION
### Jira link

[HMRC-2189](https://transformuk.atlassian.net/browse/HMRC-2189)

### What?

- [x] Raise the Lambda error alarm threshold to 5 failures over 10 minutes
- [x] Add an API Gateway 5xx alarm with the same threshold
- [x] Leave the duration alarm unchanged

### Why?

Production was alerting on single FPO search failures, which is too noisy for one-off cold-start timeouts. The upshot is we get paged for isolated blips rather than sustained failures or real user impact.

This tightens the Lambda error alarm and adds a matching API Gateway 5xx alarm so we only alert when the service is failing repeatedly or users are actually seeing 5xxs.
