### PR TITLE
BAU: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.15.12
     hooks:
       - id: ruff-check
       - id: ruff-format
@@ -25,20 +25,19 @@ repos:
         args: ["--severity=warning"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.48.0
     hooks:
-      - id: markdownlint-docker
+      - id: markdownlint-fix
         args:
-          - "--fix"
           - "--ignore"
           - terraform
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.90.12
+    rev: v3.95.3
     hooks:
       - id: trufflehog
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.8
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker

--- a/docs/understanding_cleaning.md
+++ b/docs/understanding_cleaning.md
@@ -26,7 +26,7 @@ We typically process millions of descriptions and codes from different sources i
 ## Custom cleaners
 
 | Cleaner Name | Description | Used in Training | Used in Inference |
-|--------------|-------------|------------------|-------------------|
+| -------------- | ----------- | ------------------ | ------------------- |
 | **StripExcessCharacters** | Strips leading/trailing whitespace, newlines, tabs, carriage returns, periods, and commas from subheadings and descriptions. Normalizes multiple spaces in descriptions to single spaces. | Yes | Yes |
 | **PluralCleaning** | Converts odd plural forms in descriptions (e.g., "women s" to "womens") while preserving specific forms like "size s". | Yes | No |
 | **IncorrectPairsRemover** | Removes incorrect subheading-description pairs based on a CSV file specifying descriptions, correct chapters, and codes to skip. | Yes | No |
@@ -58,10 +58,10 @@ The following outlines the various data sources we clean with a summary of the c
 - Reinforcement Muliplier - How many times we repeat this data source during training to reinforce its importance/boost output scores for the result
 
 | Data Source | Cleaners Used | Description | Reinforcement Multiplier |
-|-------------|-----------------------|-------------|-------------------------|
+| ----------- | ----------------------- | ----------- | ------------------------ |
 | Tradesets CSV | DescriptionLower, PhraseRemover, StripExcessCharacters, RemoveEmptyDescription, RemoveShortDescription, RemoveSubheadingsNotMatchingRegexes, RemoveDescriptionsMatchingRegexes, LanguageCleaning, IncorrectPairsRemover, PluralCleaning | Very large CSV file containing trade transaction data requiring comprehensive cleaning to handle noisy, real-world data. | 1 |
 | Search References | DescriptionLower, StripExcessCharacters, RemoveEmptyDescription, RemoveShortDescription, RemoveSubheadingsNotMatchingRegexes, Map2024CodesTo2025Codes | API data source authored via the admin app with search-related reference mappings for commodity codes, weighted heavily to improve search-based classification accuracy. | 10 |
-| Brands CSV | PadCodes, DescriptionLower, StripExcessCharacters, RemoveEmptyDescription, RemoveShortDescription, RemoveSubheadingsNotMatchingRegexes, Map2024CodesTo2025Codes | CSV file with brand-specific commodity descriptions and codes  | 5 |
+| Brands CSV | PadCodes, DescriptionLower, StripExcessCharacters, RemoveEmptyDescription, RemoveShortDescription, RemoveSubheadingsNotMatchingRegexes, Map2024CodesTo2025Codes | CSV file with brand-specific commodity descriptions and codes | 5 |
 | Extra References CSV | DescriptionLower, StripExcessCharacters, RemoveEmptyDescription, RemoveShortDescription, RemoveSubheadingsNotMatchingRegexes, Map2024CodesTo2025Codes | CSV file with additional reference data for commodity codes, providing authoritative mappings. Duplicates search references concept with less reinforcement. | 5 |
 | CN Data CSV | DescriptionLower, StripExcessCharacters, RemoveEmptyDescription, RemoveShortDescription, RemoveSubheadingsNotMatchingRegexes, Map2024CodesTo2025Codes, NegationCleaning | CSV file containing Combined Nomenclature (CN) data, a standard EU tariff classification system for training authoritative classifications. | 3 |
 | Vague Terms CSV | DescriptionLower, StripExcessCharacters, RemoveEmptyDescription, RemoveShortDescription, RemoveSubheadingsNotMatchingRegexes, Map2024CodesTo2025Codes | CSV file containing vague or ambiguous commodity descriptions, likely with regex patterns to identify them, used to train the model to handle non-specific terms. | 1 |

--- a/tests/training/test_negation_cleaning.py
+++ b/tests/training/test_negation_cleaning.py
@@ -29,7 +29,7 @@ class TestNegationCleaning(unittest.TestCase):
             "fabrics (textile) other than knitted, crocheted or woven - felt",
             "fabrics (textile)- felt",
         ),
-        ("I have a\u00A0non-breaking space", "i have a non-breaking space"),
+        ("I have a\u00a0non-breaking space", "i have a non-breaking space"),
         ("some text", "some text"),
         (None, ""),
         ("", ""),


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Run `pre-commit autoupdate` for stale hook refs where available.
- [x] Switch markdown linting from the Docker image hook to the Node `markdownlint-fix` hook.

### Why?

The `markdownlint-docker` hook pulls `ghcr.io/igorshubovych/markdownlint-cli:v0.48.0` in CI. Using the non-Docker hook avoids the GHCR image pull path while preserving markdown auto-fix behaviour.

### Validation

- `pre-commit validate-config`
- `pre-commit run markdownlint-fix --all-files`
- `git diff --check`
- `pre-commit run ruff-check --all-files`
- `pre-commit run ruff-format --all-files`


### Risk

**Risk level:** 🟢

**Reason for rating:**
Pre-commit hook configuration only. There is no application runtime or infrastructure behaviour change; the main risk is CI surfacing markdown or hook-version differences earlier than before.
