### PR TITLE
ci: add low-risk auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,40 @@
+name: Auto-merge low-risk PRs
+
+on:
+  pull_request:
+    types:
+      - ready_for_review
+      - labeled
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
+  workflow_run:
+    workflows:
+      - 'deploy-to-development'
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: >-
+      (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft
+      ) &&
+      (
+        github.event_name != 'pull_request_review' ||
+        github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+      )
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/auto-merge-low-risk.yml@main
+    with:
+      label: low-risk
+      merge-method: rebase
+      required-workflow: deploy-to-development.yml
+    secrets:
+      github-token: ${{ secrets.PULL_REQUEST_PAT }}


### PR DESCRIPTION
## Summary
Adds the shared low-risk auto-merge caller used across Trade Tariff product repos.

- Reuses `trade-tariff/trade-tariff-tools/.github/workflows/auto-merge-low-risk.yml@main`
- Enables auto-merge for PRs labelled `low-risk` after Copilot review and green required checks
- Uses rebase merge method (repo has merge commits disabled)

## Why
Roll out the same automerger used on backend/frontend/admin/etc. to remaining non-infrastructure repos.

## Notes
- Requires repo/org secret `PULL_REQUEST_PAT` (same as existing consumers)
- Does not change branch protection or required reviewers

Issue: No ticket/issue