### PR TITLE
fix: serverless config apiGateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ failed
 
 .envrc
 .pre-commit-config-nix.yaml
+
+.DS_Store

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,8 @@
 frameworkVersion: "3"
 service: trade-tariff-lambdas-fpo-search
 
+configValidationMode: error
+
 plugins:
   - serverless-domain-manager
 
@@ -43,9 +45,9 @@ provider:
 
   apiGateway:
     usagePlan:
-      - apiStages:
-          - api: ${self:service}-${env:STAGE}
-            stage: ${env:STAGE}
+      apiStages:
+        - apiId: ${self:service}-${env:STAGE}
+          stage: ${env:STAGE}
 
 functions:
   fpo_search:


### PR DESCRIPTION
- Fixed an issue with the serverless config where `apiStages` was an array, not an object.
- Added `.DS_Store` to `.gitignore` so it doesn't get committed.
