### PR TITLE
HMRC-2646: Upgrade Docker base image to python:3.14-slim

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,7 +55,6 @@ reference_data/CN2025_SelfText_EN_DE_FR.csv
 reference_data/brands.csv
 reference_data/extra_references.csv
 reference_data/incorrect_code_desc_pairs.csv
-requirements.txt
 serverless.yml
 target*/training_data
 target.zip

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: 3.11
+  PYTHON_VERSION: 3.14
 
 jobs:
   check:

--- a/.packer/provision
+++ b/.packer/provision
@@ -6,7 +6,7 @@ set -o nounset
 set -o pipefail
 
 GIT_REPO="trade-tariff-lambdas-fpo-search"
-PYTHON_VERSION="3.11.13"
+PYTHON_VERSION="3.14.7"
 
 if [ "$(id -u)" -eq 0 ]; then
   SUDO=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,14 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /opt/app
 
+COPY requirements.txt .
 COPY requirements_lambda.txt .
 
 # TODO: Revisit awslambdaric pin after upstream issue is fixed:
 # https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/issues/170
 RUN pip install --upgrade pip --no-cache-dir && \
     pip install -r requirements_lambda.txt --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu && \
-    pip install --no-cache-dir awslambdaric==3.3.0 && \
+    pip install --no-cache-dir awslambdaric==3.1.1 && \
     pip cache purge && \
     rm -rf /root/.cache/pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,12 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /opt/app
 
 COPY requirements_lambda.txt .
+
+# TODO: Revisit awslambdaric pin after upstream issue is fixed:
+# https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/issues/170
 RUN pip install --upgrade pip --no-cache-dir && \
     pip install -r requirements_lambda.txt --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu && \
-    pip install --no-cache-dir awslambdaric==3.1.1 && \
+    pip install --no-cache-dir awslambdaric==3.3.0 && \
     pip cache purge && \
     rm -rf /root/.cache/pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y \
     gcc \
@@ -19,11 +19,11 @@ COPY . .
 
 RUN python quantize_model.py
 
-FROM python:3.12-slim AS production
+FROM python:3.14-slim AS production
 
 WORKDIR /opt/app
 
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /opt/app .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aws_lambda_powertools==3.31.1
 dill==0.4.1
-lingua-language-detector==2.1.1
+lingua-language-detector==2.2.0
 numpy==2.4.6
 requests==2.34.2
 sentence-transformers==5.6.1

--- a/requirements_lambda.txt
+++ b/requirements_lambda.txt
@@ -1,9 +1,2 @@
-aws_lambda_powertools==3.31.1
+-r requirements.txt
 awslambdaric==4.0.2
-jmespath==1.1.0
-lingua-language-detector==2.1.1
-numpy==2.4.6
-requests==2.34.2
-sentence-transformers==5.6.1
-toml==0.10.2
-torch==2.13.0


### PR DESCRIPTION
### Jira link

[HMRC-2646](https://transformuk.atlassian.net/browse/HMRC-2646)

### What?

I have added/removed/altered:

- [x] Altered the Docker base image in both the `builder` and `production` stages from `python:3.12-slim` to `python:3.14-slim`, and updated the site-packages copy path accordingly
- [x] Altered `.github/workflows/deploy-to-development.yml` and `.packer/provision` to build against Python 3.14 instead of 3.11
- [x] Upgraded `lingua-language-detector` from 2.1.1 to 2.2.0 in `requirements.txt`
- [x] Altered `requirements_lambda.txt` to inherit from `requirements.txt` via `-r requirements.txt` instead of duplicating pins
- [x] Pinned `awslambdaric` to 3.1.1 in the Dockerfile (overriding the version resolved from `requirements_lambda.txt`) as a workaround for an [upstream issue](https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/issues/170), with a TODO to revisit once fixed
- [x] Altered the Dockerfile to also `COPY requirements.txt` into the build image, since `requirements_lambda.txt` now references it, and removed `requirements.txt` from `.dockerignore` so it's available to copy

### Why?

I am doing this because:

- This keeps the Lambda container image and build tooling on a current, supported Python runtime
- The `awslambdaric` pin works around a known upstream issue affecting newer versions
- Consolidating `requirements_lambda.txt` to inherit from `requirements.txt` avoids duplicate/drifting dependency pins

### AC

- [ ] Docker image builds successfully with `python:3.14-slim`
- [ ] Existing tests pass against the upgraded image
- [ ] Lambda deploys and runs correctly with the pinned `awslambdaric==3.1.1`