### PR TITLE
Pin serverless-domain-manager to 10.2.0 in deploy workflows

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -178,7 +178,11 @@ jobs:
 
       - run: npm install -g serverless@3
 
-      - run: npm install -g serverless-domain-manager
+      # TODO: pinned below 10.3.0 because that release switched credential resolution to
+      # getAwsSdkV3Config(), which only works with the newer `osls` v4 fork. We're still on
+      # `serverless@3` above, so latest breaks with "Resolved credential object is not valid".
+      # Unpin once this repo migrates to osls/serverless v4, or the plugin restores v3 support.
+      - run: npm install -g serverless-domain-manager@10.2.0
 
       - id: docker-tag
         run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -66,7 +66,11 @@ jobs:
 
       - run: npm install -g serverless@3
 
-      - run: npm install -g serverless-domain-manager
+      # TODO: pinned below 10.3.0 because that release switched credential resolution to
+      # getAwsSdkV3Config(), which only works with the newer `osls` v4 fork. We're still on
+      # `serverless@3` above, so latest breaks with "Resolved credential object is not valid".
+      # Unpin once this repo migrates to osls/serverless v4, or the plugin restores v3 support.
+      - run: npm install -g serverless-domain-manager@10.2.0
 
       - id: docker-tag
         run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -63,7 +63,11 @@ jobs:
 
       - run: npm install -g serverless@3
 
-      - run: npm install -g serverless-domain-manager
+      # TODO: pinned below 10.3.0 because that release switched credential resolution to
+      # getAwsSdkV3Config(), which only works with the newer `osls` v4 fork. We're still on
+      # `serverless@3` above, so latest breaks with "Resolved credential object is not valid".
+      # Unpin once this repo migrates to osls/serverless v4, or the plugin restores v3 support.
+      - run: npm install -g serverless-domain-manager@10.2.0
 
       - id: docker-tag
         run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Jira link

N/A - hotfix for a broken CI deploy, no ticket

### What?

I have added/removed/altered:

- [x] Altered the `deploy` job in `deploy-to-development.yml`, `deploy-to-staging.yml`, and `deploy-to-production.yml` to install `serverless-domain-manager@10.2.0` instead of unpinned `latest`, with a comment explaining why.

### Why?

I am doing this because:

- The `deploy-to-development` workflow started failing with `Error: V1 - Unable to fetch information about 'search.dev.trade-tariff.service.gov.uk': Resolved credential object is not valid` during the "Creating domain name before deploy" step.
- `serverless-domain-manager` was installed unpinned (`npm install -g serverless-domain-manager`), so CI always picks up `latest`, currently 10.3.1.
- Per the plugin's changelog, v10.3.0 changed credential resolution to use `provider.getAwsSdkV3Config().credentials`, which is designed for the newer `osls` v4 fork. These workflows still install `serverless@3` (this repo's `serverless.yml` is pinned to `frameworkVersion: "3"`), so under classic Serverless Framework v3 that path returns a malformed credentials object, causing the deploy to fail.
- Pinning to 10.2.0 (the last release before that credential-resolution rework) restores working deploys without touching the framework version.

### AC

- [ ] `deploy-to-development` workflow's `deploy` job completes successfully (custom domain step no longer errors)
- [ ] Same fix verified/applies cleanly for `deploy-to-staging` and `deploy-to-production`